### PR TITLE
Fixed counter value in the case of an error

### DIFF
--- a/src/main/kotlin/Scheduler.kt
+++ b/src/main/kotlin/Scheduler.kt
@@ -130,6 +130,7 @@ class Scheduler : CoroutineVerticle() {
           lookup(updateRequiredCapabilities = true)
         } catch (t: Throwable) {
           log.error("Failed to look for process chains", t)
+          pendingLookups = 0 // Reset counter. In the case of an error, lookup() might not have done it.
         }
       }
     }

--- a/src/main/kotlin/Scheduler.kt
+++ b/src/main/kotlin/Scheduler.kt
@@ -130,7 +130,6 @@ class Scheduler : CoroutineVerticle() {
           lookup(updateRequiredCapabilities = true)
         } catch (t: Throwable) {
           log.error("Failed to look for process chains", t)
-          pendingLookups = 0 // Reset counter. In the case of an error, lookup() might not have done it.
         }
       }
     }


### PR DESCRIPTION
If the lookup of process chains fails, the pendingLookups counter might not have been reset to zero. Do it in the catch block.