### PR TITLE
Access variables in process chain adapter

### DIFF
--- a/src/main/kotlin/Controller.kt
+++ b/src/main/kotlin/Controller.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import model.Submission
 import model.plugins.call
 import model.processchain.ProcessChain
+import model.workflow.Workflow
 import org.apache.commons.io.FilenameUtils
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -212,11 +213,11 @@ class Controller : CoroutineVerticle() {
    * [processChains] and returns the modified list. If there are no plugins or
    * if they did no make any modifications, the method returns the original list.
    */
-  private suspend fun applyPlugins(processChains: List<ProcessChain>): List<ProcessChain> {
+  private suspend fun applyPlugins(processChains: List<ProcessChain>, workflow: Workflow): List<ProcessChain> {
     val adapters = pluginRegistry.getProcessChainAdapters()
     var result = processChains
     for (adapter in adapters) {
-      result = adapter.call(result, vertx)
+      result = adapter.call(result, workflow, vertx)
     }
     return result
   }
@@ -290,7 +291,7 @@ class Controller : CoroutineVerticle() {
           processChainsToResume = null
           pcs
         } else {
-          val pcs = applyPlugins(generator.generate(results))
+          val pcs = applyPlugins(generator.generate(results), submission.workflow)
           if (pcs.isEmpty()) {
             break
           }

--- a/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
+++ b/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
@@ -29,9 +29,14 @@ data class ProcessChainAdapterPlugin(
     override val compiledFunction: KFunction<List<ProcessChain>> = throwPluginNeedsCompile()
 ) : DependentPlugin
 
+@Deprecated("Please pass the workflow for the process chains too",
+  ReplaceWith("call(processChains, workflowForProcessChains, vertx)", "model.workflow.Workflow")
+)
+suspend fun ProcessChainAdapterPlugin.call(processChains: List<ProcessChain>,
+    vertx: Vertx): List<ProcessChain> = call(processChains, Workflow(), vertx)
+
 suspend fun ProcessChainAdapterPlugin.call(processChains: List<ProcessChain>,
     workflow: Workflow, vertx: Vertx): List<ProcessChain> {
-
   val arguments = if (this.compiledFunction.parameters.size == 2) {
     arrayOf(processChains, vertx)
   } else {

--- a/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
+++ b/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
@@ -2,6 +2,7 @@ package model.plugins
 
 import io.vertx.core.Vertx
 import model.processchain.ProcessChain
+import model.workflow.Workflow
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.callSuspend
 
@@ -29,10 +30,16 @@ data class ProcessChainAdapterPlugin(
 ) : DependentPlugin
 
 suspend fun ProcessChainAdapterPlugin.call(processChains: List<ProcessChain>,
-    vertx: Vertx): List<ProcessChain> {
-  return if (this.compiledFunction.isSuspend) {
-    this.compiledFunction.callSuspend(processChains, vertx)
+    workflow: Workflow, vertx: Vertx): List<ProcessChain> {
+
+  val arguments = if (this.compiledFunction.parameters.size == 2) {
+    arrayOf(processChains, vertx)
   } else {
-    this.compiledFunction.call(processChains, vertx)
+    arrayOf(processChains, workflow, vertx)
+  }
+  return if (this.compiledFunction.isSuspend) {
+    this.compiledFunction.callSuspend(*arguments)
+  } else {
+    this.compiledFunction.call(*arguments)
   }
 }

--- a/src/test/kotlin/db/PluginRegistryTest.kt
+++ b/src/test/kotlin/db/PluginRegistryTest.kt
@@ -23,6 +23,7 @@ import model.processchain.Argument
 import model.processchain.ArgumentVariable
 import model.processchain.Executable
 import model.processchain.ProcessChain
+import model.workflow.Workflow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -167,10 +168,10 @@ class PluginRegistryTest {
       val pr = PluginRegistryFactory.create()
       val adapters = pr.getProcessChainAdapters()
       ctx.coVerify {
-        assertThat(adapters).hasSize(1)
+        assertThat(adapters).hasSize(2)
         val adapter = adapters[0]
         val pcs = listOf(ProcessChain())
-        val newPcs = adapter.call(pcs, vertx)
+        val newPcs = adapter.call(pcs, Workflow(), vertx)
         assertThat(newPcs).isNotSameAs(pcs)
         assertThat(newPcs).hasSize(2)
         assertThat(newPcs[0]).isSameAs(pcs[0])

--- a/src/test/resources/db/dummyProcessChainAdapter.yaml
+++ b/src/test/resources/db/dummyProcessChainAdapter.yaml
@@ -2,3 +2,8 @@
 - name: dummyProcessChainAdapter
   type: processChainAdapter
   scriptFile: db/dummyProcessChainAdapter.kts
+
+# This process chain adapter does nothing. But it uses the workflow as a parameter.
+- name: dummyProcessChainAdapterWithWorkflow
+  type: processChainAdapter
+  scriptFile: db/dummyProcessChainAdapterWithWorkflow.kts

--- a/src/test/resources/db/dummyProcessChainAdapterWithWorkflow.kts
+++ b/src/test/resources/db/dummyProcessChainAdapterWithWorkflow.kts
@@ -1,0 +1,8 @@
+import io.vertx.core.Vertx
+import model.processchain.ProcessChain
+import model.workflow.Workflow
+
+fun dummyProcessChainAdapterWithWorkflow(processChains: List<ProcessChain>, workflow: Workflow, vertx: Vertx):
+      List<ProcessChain> {
+  return processChains
+}


### PR DESCRIPTION
## Motivation
When using a lot of process chain adapters, their management becomes difficult with the time. When I want to change their behaviour I want to ensure backwards compatibility to old workflows. However, in the plugin I have no chance to react differently to different workflow versions. I only get the process chains. Currently my only option is to add dummy parameters to the services and remove them afterwards in my plugin. This increases the maintenance effort and can easily lead to problems if the removal does not work properly.

## Goal
Some kind of context would make the development of process chain adapters much easier. I want to set variables in the workflow and react to them in the adapter. 

## Idea
My first idea was a multi-level context. In this case there would have been a context on workflow level. Its variables could have been overridden in a for loop and thus a customized context would have been available for the actions contained in it. For the individual actions themselves, the context could have been overwritten again. 
This solution would have allowed very fine-grained changes. However, it would also have greatly changed the existing models and new fields would have been necessary.
I therefore decided against implementing a multi-level context. For a customized behavior of the plugins, a global context is sufficient. In most cases I do not need different behaviour within one workflow.

## Solution
A global context already exists. Each workflow has variables and a user can easily add more variables with any value. 
The only step that was missing until now was the ability to access the variables of the workflow in the process chain adapter. In this pull request a change is proposed, which will pass the list of process chains and the corresponding workflow object to the adapter.