### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 12
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Add data to VMS collection
         run: mongoimport --collection=vms --db=steep --file=${{ github.workspace }}/ui/cypress/fixtures/steep_vms.json

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
           STEEP_DB_URL: mongodb://mongo:27017/steep
 
     steps:
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2.5.0
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
     implementation("com.github.zafarkhaja:java-semver:0.9.0")
-    implementation("com.google.guava:guava:31.0.1-jre")
+    implementation("com.google.guava:guava:31.1-jre")
     implementation("com.zaxxer:HikariCP:5.0.1")
     implementation("io.pebbletemplates:pebble:3.1.5")
     implementation("io.projectreactor:reactor-core:3.4.15") // necessary for reactive MongoDB driver

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation("org.apache.ant:ant:1.10.12")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.apache.commons:commons-text:1.9")
-    implementation("org.flywaydb:flyway-core:8.5.0")
+    implementation("org.flywaydb:flyway-core:8.5.1")
     implementation("org.mongodb:mongodb-driver-reactivestreams:4.4.1")
     implementation("com.github.openstack4j.core:openstack4j:3.10")
     implementation("org.postgresql:postgresql:42.3.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation(kotlin("script-runtime"))
 
     testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.3.1")
-    testImplementation("io.mockk:mockk:1.12.2")
+    testImplementation("io.mockk:mockk:1.12.3")
     testImplementation("io.vertx:vertx-junit5:$vertxVersion")
     testImplementation("org.assertj:assertj-core:3.22.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "^2.3.1",
         "clipboard": "^2.0.10",
         "date-fns": "^2.28.0",
-        "dayjs": "^1.10.7",
+        "dayjs": "^1.10.8",
         "eslint-loader": "^4.0.2",
         "favicons": "^6.2.2",
         "highlight.js": "^10.7.2",
@@ -3025,9 +3025,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
+      "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -11053,9 +11053,9 @@
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
+      "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow=="
     },
     "debug": {
       "version": "2.6.9",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -39,7 +39,7 @@
         "spinkit": "^2.0.1",
         "svgo-loader": "^3.0.0",
         "unfetch": "^4.2.0",
-        "webpack": "^5.69.0"
+        "webpack": "^5.69.1"
       },
       "devDependencies": {
         "cypress": "^9.5.1",
@@ -8478,9 +8478,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
-      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -8491,7 +8491,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.0",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -15110,9 +15110,9 @@
       }
     },
     "webpack": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
-      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -15123,7 +15123,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.0",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -42,7 +42,7 @@
         "webpack": "^5.69.0"
       },
       "devDependencies": {
-        "cypress": "^9.5.0",
+        "cypress": "^9.5.1",
         "eslint": "^8.8.0",
         "eslint-config-next": "^12.0.10",
         "eslint-plugin-cypress": "^2.12.1"
@@ -2700,9 +2700,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
-      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.1.tgz",
+      "integrity": "sha512-H7lUWB3Svr44gz1rNnj941xmdsCljXoJa2cDneAltjI9leKLMQLm30x6jLlpQ730tiVtIbW5HdUmBzPzwzfUQg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10817,9 +10817,9 @@
       }
     },
     "cypress": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
-      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.1.tgz",
+      "integrity": "sha512-H7lUWB3Svr44gz1rNnj941xmdsCljXoJa2cDneAltjI9leKLMQLm30x6jLlpQ730tiVtIbW5HdUmBzPzwzfUQg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "json2yaml": "^1.1.0",
         "lodash": "^4.17.21",
         "mini-svg-data-uri": "^1.4.3",
-        "next": "^12.0.10",
+        "next": "^12.1.0",
         "normalize.css": "^8.0.1",
         "nprogress": "^0.2.0",
         "parse-content-range-header": "^0.2.4",
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
+      "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.1.0",
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
-      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
+      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
       "cpu": [
         "arm64"
       ],
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
-      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
+      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
-      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
+      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
       "cpu": [
         "x64"
       ],
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
-      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
+      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
       "cpu": [
         "arm"
       ],
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
-      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
       "cpu": [
         "arm64"
       ],
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
-      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
+      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
       "cpu": [
         "arm64"
       ],
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
-      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
       "cpu": [
         "x64"
       ],
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
-      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
+      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
       "cpu": [
         "x64"
       ],
@@ -863,9 +863,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
-      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
+      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
       "cpu": [
         "arm64"
       ],
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
-      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
+      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
       "cpu": [
         "ia32"
       ],
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
-      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
+      "integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
       "cpu": [
         "x64"
       ],
@@ -5979,11 +5979,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
-      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.0.tgz",
+      "integrity": "sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==",
       "dependencies": {
-        "@next/env": "12.0.10",
+        "@next/env": "12.1.0",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.0",
@@ -5996,21 +5996,21 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm64": "12.0.10",
-        "@next/swc-darwin-arm64": "12.0.10",
-        "@next/swc-darwin-x64": "12.0.10",
-        "@next/swc-linux-arm-gnueabihf": "12.0.10",
-        "@next/swc-linux-arm64-gnu": "12.0.10",
-        "@next/swc-linux-arm64-musl": "12.0.10",
-        "@next/swc-linux-x64-gnu": "12.0.10",
-        "@next/swc-linux-x64-musl": "12.0.10",
-        "@next/swc-win32-arm64-msvc": "12.0.10",
-        "@next/swc-win32-ia32-msvc": "12.0.10",
-        "@next/swc-win32-x64-msvc": "12.0.10"
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^17.0.2 || ^18.0.0-0",
         "react-dom": "^17.0.2 || ^18.0.0-0",
         "sass": "^1.3.0"
@@ -9368,9 +9368,9 @@
       }
     },
     "@next/env": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
+      "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.1.0",
@@ -9382,69 +9382,69 @@
       }
     },
     "@next/swc-android-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
-      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
+      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
-      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
+      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
-      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
+      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
-      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
+      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
-      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
-      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
+      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
-      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
-      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
+      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
-      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
+      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
-      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
+      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
-      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
+      "integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -13241,22 +13241,22 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
-      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.0.tgz",
+      "integrity": "sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==",
       "requires": {
-        "@next/env": "12.0.10",
-        "@next/swc-android-arm64": "12.0.10",
-        "@next/swc-darwin-arm64": "12.0.10",
-        "@next/swc-darwin-x64": "12.0.10",
-        "@next/swc-linux-arm-gnueabihf": "12.0.10",
-        "@next/swc-linux-arm64-gnu": "12.0.10",
-        "@next/swc-linux-arm64-musl": "12.0.10",
-        "@next/swc-linux-x64-gnu": "12.0.10",
-        "@next/swc-linux-x64-musl": "12.0.10",
-        "@next/swc-win32-arm64-msvc": "12.0.10",
-        "@next/swc-win32-ia32-msvc": "12.0.10",
-        "@next/swc-win32-x64-msvc": "12.0.10",
+        "@next/env": "12.1.0",
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,7 +25,7 @@
         "normalize.css": "^8.0.1",
         "nprogress": "^0.2.0",
         "parse-content-range-header": "^0.2.4",
-        "postcss": "^8.4.6",
+        "postcss": "^8.4.7",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-feather": "^2.0.9",
@@ -5945,9 +5945,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6637,11 +6637,11 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dependencies": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -13216,9 +13216,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -13727,11 +13727,11 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "requires": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -44,7 +44,7 @@
       "devDependencies": {
         "cypress": "^9.5.1",
         "eslint": "^8.8.0",
-        "eslint-config-next": "^12.0.10",
+        "eslint-config-next": "^12.1.0",
         "eslint-plugin-cypress": "^2.12.1"
       }
     },
@@ -734,9 +734,9 @@
       "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
-      "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.0.tgz",
+      "integrity": "sha512-WFiyvSM2G5cQmh32t/SiQuJ+I2O+FHVlK/RFw5b1565O2kEM/36EXncjt88Pa+X5oSc+1SS+tWxowWJd1lqI+g==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -3425,12 +3425,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
-      "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.0.tgz",
+      "integrity": "sha512-tBhuUgoDITcdcM7xFvensi9I5WTI4dnvH4ETGRg1U8ZKpXrZsWQFdOKIDzR3RLP5HR3xXrLviaMM4c3zVoE/pA==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.0.10",
+        "@next/eslint-plugin-next": "12.1.0",
         "@rushstack/eslint-patch": "^1.0.8",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -9373,9 +9373,9 @@
       "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
-      "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.0.tgz",
+      "integrity": "sha512-WFiyvSM2G5cQmh32t/SiQuJ+I2O+FHVlK/RFw5b1565O2kEM/36EXncjt88Pa+X5oSc+1SS+tWxowWJd1lqI+g==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -11464,12 +11464,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
-      "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.0.tgz",
+      "integrity": "sha512-tBhuUgoDITcdcM7xFvensi9I5WTI4dnvH4ETGRg1U8ZKpXrZsWQFdOKIDzR3RLP5HR3xXrLviaMM4c3zVoE/pA==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.0.10",
+        "@next/eslint-plugin-next": "12.1.0",
         "@rushstack/eslint-patch": "^1.0.8",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-import-resolver-node": "^0.3.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,7 +48,7 @@
     "webpack": "^5.69.0"
   },
   "devDependencies": {
-    "cypress": "^9.5.0",
+    "cypress": "^9.5.1",
     "eslint": "^8.8.0",
     "eslint-config-next": "^12.0.10",
     "eslint-plugin-cypress": "^2.12.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,7 +45,7 @@
     "spinkit": "^2.0.1",
     "svgo-loader": "^3.0.0",
     "unfetch": "^4.2.0",
-    "webpack": "^5.69.0"
+    "webpack": "^5.69.1"
   },
   "devDependencies": {
     "cypress": "^9.5.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
     "json2yaml": "^1.1.0",
     "lodash": "^4.17.21",
     "mini-svg-data-uri": "^1.4.3",
-    "next": "^12.0.10",
+    "next": "^12.1.0",
     "normalize.css": "^8.0.1",
     "nprogress": "^0.2.0",
     "parse-content-range-header": "^0.2.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "cypress": "^9.5.1",
     "eslint": "^8.8.0",
-    "eslint-config-next": "^12.0.10",
+    "eslint-config-next": "^12.1.0",
     "eslint-plugin-cypress": "^2.12.1"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.3.1",
     "clipboard": "^2.0.10",
     "date-fns": "^2.28.0",
-    "dayjs": "^1.10.7",
+    "dayjs": "^1.10.8",
     "eslint-loader": "^4.0.2",
     "favicons": "^6.2.2",
     "highlight.js": "^10.7.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,7 @@
     "normalize.css": "^8.0.1",
     "nprogress": "^0.2.0",
     "parse-content-range-header": "^0.2.4",
-    "postcss": "^8.4.6",
+    "postcss": "^8.4.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump actions/checkout from 2 to 3 (#175) @dependabot
* Bump guava from 31.0.1-jre to 31.1-jre (#174) @dependabot
* Bump mockk from 1.12.2 to 1.12.3 (#173) @dependabot
* Bump dayjs from 1.10.7 to 1.10.8 in /ui (#172) @dependabot
* Bump cypress from 9.5.0 to 9.5.1 in /ui (#171) @dependabot
* Bump actions/setup-java from 2.5.0 to 3 (#170) @dependabot
* Bump actions/setup-node from 2.5.1 to 3 (#169) @dependabot
* Bump eslint from 8.8.0 to 8.10.0 in /ui (#168) @dependabot
* Bump de.flapdoodle.embed.mongo from 3.3.1 to 3.4.3 (#165) @dependabot
* Bump postcss from 8.4.6 to 8.4.7 in /ui (#162) @dependabot
* Bump flyway-core from 8.5.0 to 8.5.1 (#161) @dependabot
* Bump eslint-config-next from 12.0.10 to 12.1.0 in /ui (#156) @dependabot
* Bump webpack from 5.69.0 to 5.69.1 in /ui (#155) @dependabot
* Bump next from 12.0.10 to 12.1.0 in /ui (#154) @dependabot
* Bump mongodb-driver-reactivestreams from 4.4.1 to 4.5.0 (#142) @dependabot
