### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("script-runtime"))
 
-    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.3")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.5")
     testImplementation("io.mockk:mockk:1.12.3")
     testImplementation("io.vertx:vertx-junit5:$vertxVersion")
     testImplementation("org.assertj:assertj-core:3.22.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     application
     jacoco
-    kotlin("jvm") version "1.6.10"
+    kotlin("jvm") version "1.6.20"
 }
 
 buildscript {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -32,7 +32,7 @@
         "react-timeago": "^6.2.1",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
-        "sass": "^1.49.9",
+        "sass": "^1.49.11",
         "sass-loader": "^12.6.0",
         "serve": "^13.0.2",
         "spinkit": "^2.0.1",
@@ -9034,9 +9034,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.49.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+      "version": "1.49.11",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.11.tgz",
+      "integrity": "sha512-wvS/geXgHUGs6A/4ud5BFIWKO1nKd7wYIGimDk4q4GFkJicILActpv9ueMT4eRGSsp1BdKHuw1WwAHXbhsJELQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -17503,9 +17503,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.49.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+      "version": "1.49.11",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.11.tgz",
+      "integrity": "sha512-wvS/geXgHUGs6A/4ud5BFIWKO1nKd7wYIGimDk4q4GFkJicILActpv9ueMT4eRGSsp1BdKHuw1WwAHXbhsJELQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.4.1",
-        "@popperjs/core": "^2.11.4",
+        "@popperjs/core": "^2.11.5",
         "@vertx/eventbus-bridge-client.js": "^1.0.0",
         "body-scroll-lock": "^3.1.5",
         "classnames": "^2.3.1",
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -12189,9 +12189,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg=="
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.0.8",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -43,7 +43,7 @@
       "devDependencies": {
         "@playwright/test": "^1.20.2",
         "cypress": "^9.5.3",
-        "eslint": "^8.11.0",
+        "eslint": "^8.12.0",
         "eslint-config-next": "^12.1.4",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-webpack-plugin": "^3.1.1",
@@ -4546,9 +4546,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-      "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.1",
@@ -14129,9 +14129,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-      "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -44,7 +44,7 @@
         "@playwright/test": "^1.20.2",
         "cypress": "^9.5.3",
         "eslint": "^8.11.0",
-        "eslint-config-next": "^12.1.2",
+        "eslint-config-next": "^12.1.4",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-webpack-plugin": "^3.1.1",
         "start-server-and-test": "^1.14.0"
@@ -1657,9 +1657,9 @@
       "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.2.tgz",
-      "integrity": "sha512-XqYRh6d98dpv2ynoOEC3VeNv99hxRGBuanRDKASfntdAZD9Zp4n+AugmNF0qwOQEHYgG1uvZW3A4Fi6Y/+kCQw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.4.tgz",
+      "integrity": "sha512-BRy565KVK6Cdy8LHaHTiwctLqBu/RT84RLpESug70BDJzBlV8QBvODyx/j7wGhvYqp9kvstM05lyb6JaTkSCcQ==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -4598,12 +4598,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.2.tgz",
-      "integrity": "sha512-nJgSIB5lXoOsS2yY90i5L5ucI1uko+ykhcQkGkydXqs5GdPprY8Y1NKWW3N0OEzQvFyBcf7GHb/ohB21HoeEsg==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.4.tgz",
+      "integrity": "sha512-Uj0jrVjoQbg9qerxRjSHoOOv3PEzoZxpb8G9LYct25fsflP8xIiUq0l4WEu2KSB5owuLv5hie7wSMqPEsHj+bQ==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.1.2",
+        "@next/eslint-plugin-next": "12.1.4",
         "@rushstack/eslint-patch": "1.0.8",
         "@typescript-eslint/parser": "5.10.1",
         "eslint-import-resolver-node": "0.3.4",
@@ -11970,9 +11970,9 @@
       "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.2.tgz",
-      "integrity": "sha512-XqYRh6d98dpv2ynoOEC3VeNv99hxRGBuanRDKASfntdAZD9Zp4n+AugmNF0qwOQEHYgG1uvZW3A4Fi6Y/+kCQw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.4.tgz",
+      "integrity": "sha512-BRy565KVK6Cdy8LHaHTiwctLqBu/RT84RLpESug70BDJzBlV8QBvODyx/j7wGhvYqp9kvstM05lyb6JaTkSCcQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -14293,12 +14293,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.2.tgz",
-      "integrity": "sha512-nJgSIB5lXoOsS2yY90i5L5ucI1uko+ykhcQkGkydXqs5GdPprY8Y1NKWW3N0OEzQvFyBcf7GHb/ohB21HoeEsg==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.4.tgz",
+      "integrity": "sha512-Uj0jrVjoQbg9qerxRjSHoOOv3PEzoZxpb8G9LYct25fsflP8xIiUq0l4WEu2KSB5owuLv5hie7wSMqPEsHj+bQ==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.1.2",
+        "@next/eslint-plugin-next": "12.1.4",
         "@rushstack/eslint-patch": "1.0.8",
         "@typescript-eslint/parser": "5.10.1",
         "eslint-import-resolver-node": "0.3.4",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,7 @@
         "json2yaml": "^1.1.0",
         "lodash": "^4.17.21",
         "mini-svg-data-uri": "^1.4.4",
-        "next": "^12.1.2",
+        "next": "^12.1.4",
         "normalize.css": "^8.0.1",
         "nprogress": "^0.2.0",
         "parse-content-range-header": "^0.2.4",
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.2.tgz",
-      "integrity": "sha512-A/P4ysmFScBFyu1ZV0Mr1Y89snyQhqGwsCrkEpK+itMF+y+pMqBoPVIyakUf4LXqGWJGiGFuIerihvSG70Ad8Q=="
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.4.tgz",
+      "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.1.2",
@@ -1666,9 +1666,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.2.tgz",
-      "integrity": "sha512-iwalfLBhYmCIlj09czFbovj1SmTycf0AGR8CB357wgmEN8xIuznIwSsCH87AhwQ9apfNtdeDhxvuKmhS9T3FqQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.4.tgz",
+      "integrity": "sha512-FJg/6a3s2YrUaqZ+/DJZzeZqfxbbWrynQMT1C5wlIEq9aDLXCFpPM/PiOyJh0ahxc0XPmi6uo38Poq+GJTuKWw==",
       "cpu": [
         "arm"
       ],
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.2.tgz",
-      "integrity": "sha512-ZoR0Vx7czJhTgRAcFbzTKQc2n2ChC036/uc6PbgYiI/LreEnfmsV/CiREP0pUVs5ndntOX8kBA3BSbh4zCO5tQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.4.tgz",
+      "integrity": "sha512-LXraazvQQFBgxIg3Htny6G5V5he9EK7oS4jWtMdTGIikmD/OGByOv8ZjLuVLZLtVm3UIvaAiGtlQSLecxJoJDw==",
       "cpu": [
         "arm64"
       ],
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.2.tgz",
-      "integrity": "sha512-VXv7lpqFjHwkK65CZHkjvBxlSBTG+l3O0Zl2zHniHj0xHzxJZvR8VFjV2zIMZCYSfVqeQ5yt2rjwuQ9zbpGtXQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.4.tgz",
+      "integrity": "sha512-SSST/dBymecllZxcqTCcSTCu5o1NKk9I+xcvhn/O9nH6GWjgvGgGkNqLbCarCa0jJ1ukvlBA138FagyrmZ/4rQ==",
       "cpu": [
         "arm64"
       ],
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.2.tgz",
-      "integrity": "sha512-evXxJQnXEnU+heWyun7d0UV6bhBcmoiyFGR3O3v9qdhGbeXh+SXYVxRO69juuh6V7RWRdlb1KQ0rGUNa1k0XSw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.4.tgz",
+      "integrity": "sha512-p1lwdX0TVjaoDXQVuAkjtxVBbCL/urgxiMCBwuPDO7TikpXtSRivi+mIzBj5q7ypgICFmIAOW3TyupXeoPRAnA==",
       "cpu": [
         "x64"
       ],
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.2.tgz",
-      "integrity": "sha512-LJV/wo6R0Ot7Y/20bZs00aBG4J333RT6H/5Q2AROE4Hnx7cenSktSnfU6WCnJgzYLSIHdbLs549LcZMULuVquw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.4.tgz",
+      "integrity": "sha512-67PZlgkCn3TDxacdVft0xqDCL7Io1/C4xbAs0+oSQ0xzp6OzN2RNpuKjHJrJgKd0DsE1XZ9sCP27Qv0591yfyg==",
       "cpu": [
         "arm"
       ],
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.2.tgz",
-      "integrity": "sha512-fjlYU1Y8kVjjRKyuyQBYLHPxjGOS2ox7U8TqAvtgKvd2PxqdsgW4sP+VDovRVPrZlGXNllKoJiqMO1OoR9fB6w==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.4.tgz",
+      "integrity": "sha512-OnOWixhhw7aU22TQdQLYrgpgFq0oA1wGgnjAiHJ+St7MLj82KTDyM9UcymAMbGYy6nG/TFOOHdTmRMtCRNOw0g==",
       "cpu": [
         "arm64"
       ],
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.2.tgz",
-      "integrity": "sha512-Y1JRDMHqSjLObjyrD1hf6ePrJcOF/mkw+LbAzoNgrHL1dSuIAqcz3jYunJt8T7Yw48xSJy6LPSL9BclAHwEwOA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.4.tgz",
+      "integrity": "sha512-UoRMzPZnsAavdWtVylYxH8DNC7Uy0i6RrvNwT4PyQVdfANBn2omsUkcH5lgS2O7oaz0nAYLk1vqyZDO7+tJotA==",
       "cpu": [
         "arm64"
       ],
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.2.tgz",
-      "integrity": "sha512-5N4QSRT60ikQqCU8iHfYZzlhg6MFTLsKhMTARmhn8wLtZfN9VVyTFwZrJQWjV64dZc4JFeXDANGao8fm55y6bw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.4.tgz",
+      "integrity": "sha512-nM+MA/frxlTLUKLJKorctdI20/ugfHRjVEEkcLp/58LGG7slNaP1E5d5dRA1yX6ISjPcQAkywas5VlGCg+uTvA==",
       "cpu": [
         "x64"
       ],
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.2.tgz",
-      "integrity": "sha512-b32F/xAgdYG4Pt0foFzhF+2uhvNxnEj7aJNp1R4EhZotdej2PzvFWcP/dGkc7MJl205pBz5oC3gHyILIIlW6XA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.4.tgz",
+      "integrity": "sha512-GoRHxkuW4u4yKw734B9SzxJwVdyEJosaZ62P7ifOwcujTxhgBt3y76V2nNUrsSuopcKI2ZTDjaa+2wd5zyeXbA==",
       "cpu": [
         "x64"
       ],
@@ -1801,9 +1801,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.2.tgz",
-      "integrity": "sha512-hVOcGmWDeVwO00Aclopsj6MoYhfJl5zA4vjAai9KjgclQTFZa/DC0vQjgKAHHKGT5oMHgjiq/G7L6P1/UfwYnw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.4.tgz",
+      "integrity": "sha512-6TQkQze0ievXwHJcVUrIULwCYVe3ccX6T0JgZ1SiMeXpHxISN7VJF/O8uSCw1JvXZYZ6ud0CJ7nfC5HXivgfPg==",
       "cpu": [
         "arm64"
       ],
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.2.tgz",
-      "integrity": "sha512-wnVDGIVz2pR3vIkyN6IE+1NvMSBrBj1jba11iR16m8TAPzZH/PrNsxr0a9N5VavEXXLcQpoUVvT+N7nflbRAHg==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.4.tgz",
+      "integrity": "sha512-CsbX/IXuZ5VSmWCpSetG2HD6VO5FTsO39WNp2IR2Ut/uom9XtLDJAZqjQEnbUTLGHuwDKFjrIO3LkhtROXLE/g==",
       "cpu": [
         "ia32"
       ],
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.2.tgz",
-      "integrity": "sha512-MLNcurEpQp0+7OU9261f7PkN52xTGkfrt4IYTIXau7DO/aHj927oK6piIJdl9EOHdX/KN5W6qlyErj170PSHtw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.4.tgz",
+      "integrity": "sha512-JtYuWzKXKLDMgE/xTcFtCm1MiCIRaAc5XYZfYX3n/ZWSI1SJS/GMm+Su0SAHJgRFavJh6U/p998YwO/iGTIgqQ==",
       "cpu": [
         "x64"
       ],
@@ -7563,15 +7563,14 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.2.tgz",
-      "integrity": "sha512-JHPCsnFTBO0Z4SQxSYc611UA1WA+r/3y3Neg66AH5/gSO/oksfRnFw/zGX/FZ9+oOUHS9y3wJFawNpVYR2gJSQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.4.tgz",
+      "integrity": "sha512-DA4g97BM4Z0nKtDvCTm58RxdvoQyYzeg0AeVbh0N4Y/D8ELrNu47lQeEgRGF8hV4eQ+Sal90zxrJQQG/mPQ8CQ==",
       "dependencies": {
-        "@next/env": "12.1.2",
+        "@next/env": "12.1.4",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
-        "styled-jsx": "5.0.1",
-        "use-subscription": "1.5.1"
+        "styled-jsx": "5.0.1"
       },
       "bin": {
         "next": "dist/bin/next"
@@ -7580,18 +7579,18 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.1.2",
-        "@next/swc-android-arm64": "12.1.2",
-        "@next/swc-darwin-arm64": "12.1.2",
-        "@next/swc-darwin-x64": "12.1.2",
-        "@next/swc-linux-arm-gnueabihf": "12.1.2",
-        "@next/swc-linux-arm64-gnu": "12.1.2",
-        "@next/swc-linux-arm64-musl": "12.1.2",
-        "@next/swc-linux-x64-gnu": "12.1.2",
-        "@next/swc-linux-x64-musl": "12.1.2",
-        "@next/swc-win32-arm64-msvc": "12.1.2",
-        "@next/swc-win32-ia32-msvc": "12.1.2",
-        "@next/swc-win32-x64-msvc": "12.1.2"
+        "@next/swc-android-arm-eabi": "12.1.4",
+        "@next/swc-android-arm64": "12.1.4",
+        "@next/swc-darwin-arm64": "12.1.4",
+        "@next/swc-darwin-x64": "12.1.4",
+        "@next/swc-linux-arm-gnueabihf": "12.1.4",
+        "@next/swc-linux-arm64-gnu": "12.1.4",
+        "@next/swc-linux-arm64-musl": "12.1.4",
+        "@next/swc-linux-x64-gnu": "12.1.4",
+        "@next/swc-linux-x64-musl": "12.1.4",
+        "@next/swc-win32-arm64-msvc": "12.1.4",
+        "@next/swc-win32-ia32-msvc": "12.1.4",
+        "@next/swc-win32-x64-msvc": "12.1.4"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -10313,17 +10312,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/utif": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
@@ -11977,9 +11965,9 @@
       }
     },
     "@next/env": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.2.tgz",
-      "integrity": "sha512-A/P4ysmFScBFyu1ZV0Mr1Y89snyQhqGwsCrkEpK+itMF+y+pMqBoPVIyakUf4LXqGWJGiGFuIerihvSG70Ad8Q=="
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.4.tgz",
+      "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.1.2",
@@ -11991,75 +11979,75 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.2.tgz",
-      "integrity": "sha512-iwalfLBhYmCIlj09czFbovj1SmTycf0AGR8CB357wgmEN8xIuznIwSsCH87AhwQ9apfNtdeDhxvuKmhS9T3FqQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.4.tgz",
+      "integrity": "sha512-FJg/6a3s2YrUaqZ+/DJZzeZqfxbbWrynQMT1C5wlIEq9aDLXCFpPM/PiOyJh0ahxc0XPmi6uo38Poq+GJTuKWw==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.2.tgz",
-      "integrity": "sha512-ZoR0Vx7czJhTgRAcFbzTKQc2n2ChC036/uc6PbgYiI/LreEnfmsV/CiREP0pUVs5ndntOX8kBA3BSbh4zCO5tQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.4.tgz",
+      "integrity": "sha512-LXraazvQQFBgxIg3Htny6G5V5he9EK7oS4jWtMdTGIikmD/OGByOv8ZjLuVLZLtVm3UIvaAiGtlQSLecxJoJDw==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.2.tgz",
-      "integrity": "sha512-VXv7lpqFjHwkK65CZHkjvBxlSBTG+l3O0Zl2zHniHj0xHzxJZvR8VFjV2zIMZCYSfVqeQ5yt2rjwuQ9zbpGtXQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.4.tgz",
+      "integrity": "sha512-SSST/dBymecllZxcqTCcSTCu5o1NKk9I+xcvhn/O9nH6GWjgvGgGkNqLbCarCa0jJ1ukvlBA138FagyrmZ/4rQ==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.2.tgz",
-      "integrity": "sha512-evXxJQnXEnU+heWyun7d0UV6bhBcmoiyFGR3O3v9qdhGbeXh+SXYVxRO69juuh6V7RWRdlb1KQ0rGUNa1k0XSw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.4.tgz",
+      "integrity": "sha512-p1lwdX0TVjaoDXQVuAkjtxVBbCL/urgxiMCBwuPDO7TikpXtSRivi+mIzBj5q7ypgICFmIAOW3TyupXeoPRAnA==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.2.tgz",
-      "integrity": "sha512-LJV/wo6R0Ot7Y/20bZs00aBG4J333RT6H/5Q2AROE4Hnx7cenSktSnfU6WCnJgzYLSIHdbLs549LcZMULuVquw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.4.tgz",
+      "integrity": "sha512-67PZlgkCn3TDxacdVft0xqDCL7Io1/C4xbAs0+oSQ0xzp6OzN2RNpuKjHJrJgKd0DsE1XZ9sCP27Qv0591yfyg==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.2.tgz",
-      "integrity": "sha512-fjlYU1Y8kVjjRKyuyQBYLHPxjGOS2ox7U8TqAvtgKvd2PxqdsgW4sP+VDovRVPrZlGXNllKoJiqMO1OoR9fB6w==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.4.tgz",
+      "integrity": "sha512-OnOWixhhw7aU22TQdQLYrgpgFq0oA1wGgnjAiHJ+St7MLj82KTDyM9UcymAMbGYy6nG/TFOOHdTmRMtCRNOw0g==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.2.tgz",
-      "integrity": "sha512-Y1JRDMHqSjLObjyrD1hf6ePrJcOF/mkw+LbAzoNgrHL1dSuIAqcz3jYunJt8T7Yw48xSJy6LPSL9BclAHwEwOA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.4.tgz",
+      "integrity": "sha512-UoRMzPZnsAavdWtVylYxH8DNC7Uy0i6RrvNwT4PyQVdfANBn2omsUkcH5lgS2O7oaz0nAYLk1vqyZDO7+tJotA==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.2.tgz",
-      "integrity": "sha512-5N4QSRT60ikQqCU8iHfYZzlhg6MFTLsKhMTARmhn8wLtZfN9VVyTFwZrJQWjV64dZc4JFeXDANGao8fm55y6bw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.4.tgz",
+      "integrity": "sha512-nM+MA/frxlTLUKLJKorctdI20/ugfHRjVEEkcLp/58LGG7slNaP1E5d5dRA1yX6ISjPcQAkywas5VlGCg+uTvA==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.2.tgz",
-      "integrity": "sha512-b32F/xAgdYG4Pt0foFzhF+2uhvNxnEj7aJNp1R4EhZotdej2PzvFWcP/dGkc7MJl205pBz5oC3gHyILIIlW6XA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.4.tgz",
+      "integrity": "sha512-GoRHxkuW4u4yKw734B9SzxJwVdyEJosaZ62P7ifOwcujTxhgBt3y76V2nNUrsSuopcKI2ZTDjaa+2wd5zyeXbA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.2.tgz",
-      "integrity": "sha512-hVOcGmWDeVwO00Aclopsj6MoYhfJl5zA4vjAai9KjgclQTFZa/DC0vQjgKAHHKGT5oMHgjiq/G7L6P1/UfwYnw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.4.tgz",
+      "integrity": "sha512-6TQkQze0ievXwHJcVUrIULwCYVe3ccX6T0JgZ1SiMeXpHxISN7VJF/O8uSCw1JvXZYZ6ud0CJ7nfC5HXivgfPg==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.2.tgz",
-      "integrity": "sha512-wnVDGIVz2pR3vIkyN6IE+1NvMSBrBj1jba11iR16m8TAPzZH/PrNsxr0a9N5VavEXXLcQpoUVvT+N7nflbRAHg==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.4.tgz",
+      "integrity": "sha512-CsbX/IXuZ5VSmWCpSetG2HD6VO5FTsO39WNp2IR2Ut/uom9XtLDJAZqjQEnbUTLGHuwDKFjrIO3LkhtROXLE/g==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.2.tgz",
-      "integrity": "sha512-MLNcurEpQp0+7OU9261f7PkN52xTGkfrt4IYTIXau7DO/aHj927oK6piIJdl9EOHdX/KN5W6qlyErj170PSHtw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.4.tgz",
+      "integrity": "sha512-JtYuWzKXKLDMgE/xTcFtCm1MiCIRaAc5XYZfYX3n/ZWSI1SJS/GMm+Su0SAHJgRFavJh6U/p998YwO/iGTIgqQ==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -16400,27 +16388,26 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.2.tgz",
-      "integrity": "sha512-JHPCsnFTBO0Z4SQxSYc611UA1WA+r/3y3Neg66AH5/gSO/oksfRnFw/zGX/FZ9+oOUHS9y3wJFawNpVYR2gJSQ==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.4.tgz",
+      "integrity": "sha512-DA4g97BM4Z0nKtDvCTm58RxdvoQyYzeg0AeVbh0N4Y/D8ELrNu47lQeEgRGF8hV4eQ+Sal90zxrJQQG/mPQ8CQ==",
       "requires": {
-        "@next/env": "12.1.2",
-        "@next/swc-android-arm-eabi": "12.1.2",
-        "@next/swc-android-arm64": "12.1.2",
-        "@next/swc-darwin-arm64": "12.1.2",
-        "@next/swc-darwin-x64": "12.1.2",
-        "@next/swc-linux-arm-gnueabihf": "12.1.2",
-        "@next/swc-linux-arm64-gnu": "12.1.2",
-        "@next/swc-linux-arm64-musl": "12.1.2",
-        "@next/swc-linux-x64-gnu": "12.1.2",
-        "@next/swc-linux-x64-musl": "12.1.2",
-        "@next/swc-win32-arm64-msvc": "12.1.2",
-        "@next/swc-win32-ia32-msvc": "12.1.2",
-        "@next/swc-win32-x64-msvc": "12.1.2",
+        "@next/env": "12.1.4",
+        "@next/swc-android-arm-eabi": "12.1.4",
+        "@next/swc-android-arm64": "12.1.4",
+        "@next/swc-darwin-arm64": "12.1.4",
+        "@next/swc-darwin-x64": "12.1.4",
+        "@next/swc-linux-arm-gnueabihf": "12.1.4",
+        "@next/swc-linux-arm64-gnu": "12.1.4",
+        "@next/swc-linux-arm64-musl": "12.1.4",
+        "@next/swc-linux-x64-gnu": "12.1.4",
+        "@next/swc-linux-x64-musl": "12.1.4",
+        "@next/swc-win32-arm64-msvc": "12.1.4",
+        "@next/swc-win32-ia32-msvc": "12.1.4",
+        "@next/swc-win32-x64-msvc": "12.1.4",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
-        "styled-jsx": "5.0.1",
-        "use-subscription": "1.5.1"
+        "styled-jsx": "5.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -18433,14 +18420,6 @@
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
         "ip-regex": "^1.0.1"
-      }
-    },
-    "use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "requires": {
-        "object-assign": "^4.1.1"
       }
     },
     "utif": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,7 +38,7 @@
         "spinkit": "^2.0.1",
         "svgo-loader": "^3.0.0",
         "unfetch": "^4.2.0",
-        "webpack": "^5.70.0"
+        "webpack": "^5.71.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.20.2",
@@ -10417,9 +10417,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.70.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
-      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+      "version": "5.71.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
+      "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -18517,9 +18517,9 @@
       }
     },
     "webpack": {
-      "version": "5.70.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
-      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+      "version": "5.71.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
+      "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "@playwright/test": "^1.20.2",
     "cypress": "^9.5.3",
     "eslint": "^8.11.0",
-    "eslint-config-next": "^12.1.2",
+    "eslint-config-next": "^12.1.4",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-webpack-plugin": "^3.1.1",
     "start-server-and-test": "^1.14.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@monaco-editor/react": "^4.4.1",
-    "@popperjs/core": "^2.11.4",
+    "@popperjs/core": "^2.11.5",
     "@vertx/eventbus-bridge-client.js": "^1.0.0",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.3.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "react-timeago": "^6.2.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
-    "sass": "^1.49.9",
+    "sass": "^1.49.11",
     "sass-loader": "^12.6.0",
     "serve": "^13.0.2",
     "spinkit": "^2.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,7 +47,7 @@
     "spinkit": "^2.0.1",
     "svgo-loader": "^3.0.0",
     "unfetch": "^4.2.0",
-    "webpack": "^5.70.0"
+    "webpack": "^5.71.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.20.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "json2yaml": "^1.1.0",
     "lodash": "^4.17.21",
     "mini-svg-data-uri": "^1.4.4",
-    "next": "^12.1.2",
+    "next": "^12.1.4",
     "normalize.css": "^8.0.1",
     "nprogress": "^0.2.0",
     "parse-content-range-header": "^0.2.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@playwright/test": "^1.20.2",
     "cypress": "^9.5.3",
-    "eslint": "^8.11.0",
+    "eslint": "^8.12.0",
     "eslint-config-next": "^12.1.4",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-webpack-plugin": "^3.1.1",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump @popperjs/core from 2.11.4 to 2.11.5 in /ui (#219) @dependabot
* Bump jvm from 1.6.10 to 1.6.20 (#218) @dependabot
* Bump webpack from 5.70.0 to 5.71.0 in /ui (#217) @dependabot
* Bump sass from 1.49.9 to 1.49.11 in /ui (#216) @dependabot
* Bump de.flapdoodle.embed.mongo from 3.4.3 to 3.4.5 (#215) @dependabot
* Bump next from 12.1.2 to 12.1.4 in /ui (#214) @dependabot
* Bump eslint-config-next from 12.1.2 to 12.1.4 in /ui (#213) @dependabot
* Bump react and react-dom in /ui (#207) @dependabot
* Bump eslint from 8.11.0 to 8.12.0 in /ui (#198) @dependabot
