### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -45,7 +45,7 @@ jobs:
           wait-on-timeout: 300
           config: baseUrl=http://localhost:8081
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash) -s build/reports/jacoco
 
       - name: Upload install directory as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: steep-install
           path: build/install

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download install directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: steep-install
           path: build/install

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.0.1")
     implementation("io.airlift:aircompressor:0.21")
     implementation("io.pebbletemplates:pebble:3.1.5")
-    implementation("io.projectreactor:reactor-core:3.4.16") // necessary for reactive MongoDB driver
+    implementation("io.projectreactor:reactor-core:3.4.17") // necessary for reactive MongoDB driver
     implementation("io.prometheus:simpleclient:$prometheusClientVersion")
     implementation("io.micrometer:micrometer-registry-prometheus:1.8.5")
     implementation("org.apache.ant:ant:1.10.12")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation("org.apache.ant:ant:1.10.12")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.apache.commons:commons-text:1.9")
-    implementation("org.flywaydb:flyway-core:8.5.5")
+    implementation("org.flywaydb:flyway-core:8.5.8")
     implementation("org.mongodb:mongodb-driver-reactivestreams:4.5.1")
     implementation("com.github.openstack4j.core:openstack4j:3.10")
     implementation("org.postgresql:postgresql:42.3.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("io.pebbletemplates:pebble:3.1.5")
     implementation("io.projectreactor:reactor-core:3.4.16") // necessary for reactive MongoDB driver
     implementation("io.prometheus:simpleclient:$prometheusClientVersion")
-    implementation("io.micrometer:micrometer-registry-prometheus:1.8.4")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.8.5")
     implementation("org.apache.ant:ant:1.10.12")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.apache.commons:commons-text:1.9")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -44,7 +44,7 @@
         "@playwright/test": "^1.21.0",
         "cypress": "^9.5.3",
         "eslint": "^8.12.0",
-        "eslint-config-next": "^12.1.4",
+        "eslint-config-next": "^12.1.5",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-webpack-plugin": "^3.1.1",
         "start-server-and-test": "^1.14.0"
@@ -1657,9 +1657,9 @@
       "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.4.tgz",
-      "integrity": "sha512-BRy565KVK6Cdy8LHaHTiwctLqBu/RT84RLpESug70BDJzBlV8QBvODyx/j7wGhvYqp9kvstM05lyb6JaTkSCcQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.5.tgz",
+      "integrity": "sha512-Cnb8ERC5bNKBFrnMH6203sp/b0Y78QRx1XsFu+86oBtDBmQmOFoHu7teQjHm69ER73XKK3aGaeoLiXacHoUFsg==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -4598,12 +4598,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.4.tgz",
-      "integrity": "sha512-Uj0jrVjoQbg9qerxRjSHoOOv3PEzoZxpb8G9LYct25fsflP8xIiUq0l4WEu2KSB5owuLv5hie7wSMqPEsHj+bQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.5.tgz",
+      "integrity": "sha512-P+DCt5ti63KhC0qNLzrAmPcwRGq8pYqgcf/NNr1E+WjCrMkWdCAXkIANTquo+kcO1adR2k1lTo5GCrNUtKy4hQ==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.1.4",
+        "@next/eslint-plugin-next": "12.1.5",
         "@rushstack/eslint-patch": "1.0.8",
         "@typescript-eslint/parser": "5.10.1",
         "eslint-import-resolver-node": "0.3.4",
@@ -11970,9 +11970,9 @@
       "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.4.tgz",
-      "integrity": "sha512-BRy565KVK6Cdy8LHaHTiwctLqBu/RT84RLpESug70BDJzBlV8QBvODyx/j7wGhvYqp9kvstM05lyb6JaTkSCcQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.5.tgz",
+      "integrity": "sha512-Cnb8ERC5bNKBFrnMH6203sp/b0Y78QRx1XsFu+86oBtDBmQmOFoHu7teQjHm69ER73XKK3aGaeoLiXacHoUFsg==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -14293,12 +14293,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.4.tgz",
-      "integrity": "sha512-Uj0jrVjoQbg9qerxRjSHoOOv3PEzoZxpb8G9LYct25fsflP8xIiUq0l4WEu2KSB5owuLv5hie7wSMqPEsHj+bQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.5.tgz",
+      "integrity": "sha512-P+DCt5ti63KhC0qNLzrAmPcwRGq8pYqgcf/NNr1E+WjCrMkWdCAXkIANTquo+kcO1adR2k1lTo5GCrNUtKy4hQ==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.1.4",
+        "@next/eslint-plugin-next": "12.1.5",
         "@rushstack/eslint-patch": "1.0.8",
         "@typescript-eslint/parser": "5.10.1",
         "eslint-import-resolver-node": "0.3.4",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,7 +7,7 @@
       "name": "steep-ui",
       "license": "Apache-2.0",
       "dependencies": {
-        "@monaco-editor/react": "^4.4.1",
+        "@monaco-editor/react": "^4.4.2",
         "@popperjs/core": "^2.11.5",
         "@vertx/eventbus-bridge-client.js": "^1.0.0",
         "body-scroll-lock": "^3.1.5",
@@ -1638,17 +1638,17 @@
       }
     },
     "node_modules/@monaco-editor/react": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.1.tgz",
-      "integrity": "sha512-95E/XPC4dbm/7qdkhSsU/a1kRgcn2PYhRTVIc+/cixWCZrwRURW1DRPaIZ2lOawBJ6kAOLywxuD4A4UmbT0ZIw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.2.tgz",
+      "integrity": "sha512-QwQKkP5zXK8oA6uMpZcyQqYKQbMFUIE1Z9gPhYajk4qXdt/kGCu3RvO9SGKGlS9MSciCyd3WjEksVMDoyxQk4w==",
       "dependencies": {
         "@monaco-editor/loader": "^1.3.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
         "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -11956,9 +11956,9 @@
       }
     },
     "@monaco-editor/react": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.1.tgz",
-      "integrity": "sha512-95E/XPC4dbm/7qdkhSsU/a1kRgcn2PYhRTVIc+/cixWCZrwRURW1DRPaIZ2lOawBJ6kAOLywxuD4A4UmbT0ZIw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.2.tgz",
+      "integrity": "sha512-QwQKkP5zXK8oA6uMpZcyQqYKQbMFUIE1Z9gPhYajk4qXdt/kGCu3RvO9SGKGlS9MSciCyd3WjEksVMDoyxQk4w==",
       "requires": {
         "@monaco-editor/loader": "^1.3.0",
         "prop-types": "^15.7.2"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -32,7 +32,7 @@
         "react-timeago": "^6.2.1",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
-        "sass": "^1.49.11",
+        "sass": "^1.50.0",
         "sass-loader": "^12.6.0",
         "serve": "^13.0.2",
         "spinkit": "^2.0.1",
@@ -9033,9 +9033,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.49.11",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.11.tgz",
-      "integrity": "sha512-wvS/geXgHUGs6A/4ud5BFIWKO1nKd7wYIGimDk4q4GFkJicILActpv9ueMT4eRGSsp1BdKHuw1WwAHXbhsJELQ==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -17490,9 +17490,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.49.11",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.11.tgz",
-      "integrity": "sha512-wvS/geXgHUGs6A/4ud5BFIWKO1nKd7wYIGimDk4q4GFkJicILActpv9ueMT4eRGSsp1BdKHuw1WwAHXbhsJELQ==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,7 @@
         "json2yaml": "^1.1.0",
         "lodash": "^4.17.21",
         "mini-svg-data-uri": "^1.4.4",
-        "next": "^12.1.4",
+        "next": "^12.1.5",
         "normalize.css": "^8.0.1",
         "nprogress": "^0.2.0",
         "parse-content-range-header": "^0.2.4",
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.4.tgz",
-      "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.5.tgz",
+      "integrity": "sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.1.5",
@@ -1666,9 +1666,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.4.tgz",
-      "integrity": "sha512-FJg/6a3s2YrUaqZ+/DJZzeZqfxbbWrynQMT1C5wlIEq9aDLXCFpPM/PiOyJh0ahxc0XPmi6uo38Poq+GJTuKWw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.5.tgz",
+      "integrity": "sha512-SKnGTdYcoN04Y2DvE0/Y7/MjkA+ltsmbuH/y/hR7Ob7tsj+8ZdOYuk+YvW1B8dY20nDPHP58XgDTSm2nA8BzzA==",
       "cpu": [
         "arm"
       ],
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.4.tgz",
-      "integrity": "sha512-LXraazvQQFBgxIg3Htny6G5V5he9EK7oS4jWtMdTGIikmD/OGByOv8ZjLuVLZLtVm3UIvaAiGtlQSLecxJoJDw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.5.tgz",
+      "integrity": "sha512-YXiqgQ/9Rxg1dXp6brXbeQM1JDx9SwUY/36JiE+36FXqYEmDYbxld9qkX6GEzkc5rbwJ+RCitargnzEtwGW0mw==",
       "cpu": [
         "arm64"
       ],
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.4.tgz",
-      "integrity": "sha512-SSST/dBymecllZxcqTCcSTCu5o1NKk9I+xcvhn/O9nH6GWjgvGgGkNqLbCarCa0jJ1ukvlBA138FagyrmZ/4rQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.5.tgz",
+      "integrity": "sha512-y8mhldb/WFZ6lFeowkGfi0cO/lBdiBqDk4T4LZLvCpoQp4Or/NzUN6P5NzBQZ5/b4oUHM/wQICEM+1wKA4qIVw==",
       "cpu": [
         "arm64"
       ],
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.4.tgz",
-      "integrity": "sha512-p1lwdX0TVjaoDXQVuAkjtxVBbCL/urgxiMCBwuPDO7TikpXtSRivi+mIzBj5q7ypgICFmIAOW3TyupXeoPRAnA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.5.tgz",
+      "integrity": "sha512-wqJ3X7WQdTwSGi0kIDEmzw34QHISRIQ5uvC+VXmsIlCPFcMA+zM5723uh8NfuKGquDMiEMS31a83QgkuHMYbwQ==",
       "cpu": [
         "x64"
       ],
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.4.tgz",
-      "integrity": "sha512-67PZlgkCn3TDxacdVft0xqDCL7Io1/C4xbAs0+oSQ0xzp6OzN2RNpuKjHJrJgKd0DsE1XZ9sCP27Qv0591yfyg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.5.tgz",
+      "integrity": "sha512-WnhdM5duONMvt2CncAl+9pim0wBxDS2lHoo7ub/o/i1bRbs11UTzosKzEXVaTDCUkCX2c32lIDi1WcN2ZPkcdw==",
       "cpu": [
         "arm"
       ],
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.4.tgz",
-      "integrity": "sha512-OnOWixhhw7aU22TQdQLYrgpgFq0oA1wGgnjAiHJ+St7MLj82KTDyM9UcymAMbGYy6nG/TFOOHdTmRMtCRNOw0g==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.5.tgz",
+      "integrity": "sha512-Jq2H68yQ4bLUhR/XQnbw3LDW0GMQn355qx6rU36BthDLeGue7YV7MqNPa8GKvrpPocEMW77nWx/1yI6w6J07gw==",
       "cpu": [
         "arm64"
       ],
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.4.tgz",
-      "integrity": "sha512-UoRMzPZnsAavdWtVylYxH8DNC7Uy0i6RrvNwT4PyQVdfANBn2omsUkcH5lgS2O7oaz0nAYLk1vqyZDO7+tJotA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.5.tgz",
+      "integrity": "sha512-KgPjwdbhDqXI7ghNN8V/WAiLquc9Ebe8KBrNNEL0NQr+yd9CyKJ6KqjayVkmX+hbHzbyvbui/5wh/p3CZQ9xcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.4.tgz",
-      "integrity": "sha512-nM+MA/frxlTLUKLJKorctdI20/ugfHRjVEEkcLp/58LGG7slNaP1E5d5dRA1yX6ISjPcQAkywas5VlGCg+uTvA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.5.tgz",
+      "integrity": "sha512-O2ErUTvCJ6DkNTSr9pbu1n3tcqykqE/ebty1rwClzIYdOgpB3T2MfEPP+K7GhUR87wmN/hlihO9ch7qpVFDGKw==",
       "cpu": [
         "x64"
       ],
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.4.tgz",
-      "integrity": "sha512-GoRHxkuW4u4yKw734B9SzxJwVdyEJosaZ62P7ifOwcujTxhgBt3y76V2nNUrsSuopcKI2ZTDjaa+2wd5zyeXbA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.5.tgz",
+      "integrity": "sha512-1eIlZmlO/VRjxxzUBcVosf54AFU3ltAzHi+BJA+9U/lPxCYIsT+R4uO3QksRzRjKWhVQMRjEnlXyyq5SKJm7BA==",
       "cpu": [
         "x64"
       ],
@@ -1801,9 +1801,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.4.tgz",
-      "integrity": "sha512-6TQkQze0ievXwHJcVUrIULwCYVe3ccX6T0JgZ1SiMeXpHxISN7VJF/O8uSCw1JvXZYZ6ud0CJ7nfC5HXivgfPg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.5.tgz",
+      "integrity": "sha512-oromsfokbEuVb0CBLLE7R9qX3KGXucZpsojLpzUh1QJjuy1QkrPJncwr8xmWQnwgtQ6ecMWXgXPB+qtvizT9Tw==",
       "cpu": [
         "arm64"
       ],
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.4.tgz",
-      "integrity": "sha512-CsbX/IXuZ5VSmWCpSetG2HD6VO5FTsO39WNp2IR2Ut/uom9XtLDJAZqjQEnbUTLGHuwDKFjrIO3LkhtROXLE/g==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.5.tgz",
+      "integrity": "sha512-a/51L5KzBpeZSW9LbekMo3I3Cwul+V+QKwbEIMA+Qwb2qrlcn1L9h3lt8cHqNTFt2y72ce6aTwDTw1lyi5oIRA==",
       "cpu": [
         "ia32"
       ],
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.4.tgz",
-      "integrity": "sha512-JtYuWzKXKLDMgE/xTcFtCm1MiCIRaAc5XYZfYX3n/ZWSI1SJS/GMm+Su0SAHJgRFavJh6U/p998YwO/iGTIgqQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.5.tgz",
+      "integrity": "sha512-/SoXW1Ntpmpw3AXAzfDRaQidnd8kbZ2oSni8u5z0yw6t4RwJvmdZy1eOaAADRThWKV+2oU90++LSnXJIwBRWYQ==",
       "cpu": [
         "x64"
       ],
@@ -7563,11 +7563,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.4.tgz",
-      "integrity": "sha512-DA4g97BM4Z0nKtDvCTm58RxdvoQyYzeg0AeVbh0N4Y/D8ELrNu47lQeEgRGF8hV4eQ+Sal90zxrJQQG/mPQ8CQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.5.tgz",
+      "integrity": "sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==",
       "dependencies": {
-        "@next/env": "12.1.4",
+        "@next/env": "12.1.5",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.1"
@@ -7579,18 +7579,18 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.1.4",
-        "@next/swc-android-arm64": "12.1.4",
-        "@next/swc-darwin-arm64": "12.1.4",
-        "@next/swc-darwin-x64": "12.1.4",
-        "@next/swc-linux-arm-gnueabihf": "12.1.4",
-        "@next/swc-linux-arm64-gnu": "12.1.4",
-        "@next/swc-linux-arm64-musl": "12.1.4",
-        "@next/swc-linux-x64-gnu": "12.1.4",
-        "@next/swc-linux-x64-musl": "12.1.4",
-        "@next/swc-win32-arm64-msvc": "12.1.4",
-        "@next/swc-win32-ia32-msvc": "12.1.4",
-        "@next/swc-win32-x64-msvc": "12.1.4"
+        "@next/swc-android-arm-eabi": "12.1.5",
+        "@next/swc-android-arm64": "12.1.5",
+        "@next/swc-darwin-arm64": "12.1.5",
+        "@next/swc-darwin-x64": "12.1.5",
+        "@next/swc-linux-arm-gnueabihf": "12.1.5",
+        "@next/swc-linux-arm64-gnu": "12.1.5",
+        "@next/swc-linux-arm64-musl": "12.1.5",
+        "@next/swc-linux-x64-gnu": "12.1.5",
+        "@next/swc-linux-x64-musl": "12.1.5",
+        "@next/swc-win32-arm64-msvc": "12.1.5",
+        "@next/swc-win32-ia32-msvc": "12.1.5",
+        "@next/swc-win32-x64-msvc": "12.1.5"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -11965,9 +11965,9 @@
       }
     },
     "@next/env": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.4.tgz",
-      "integrity": "sha512-7gQwotJDKnfMxxXd8xJ2vsX5AzyDxO3zou0+QOXX8/unypA6icw5+wf6A62yKZ6qQ4UZHHxS68pb6UV+wNneXg=="
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.5.tgz",
+      "integrity": "sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.1.5",
@@ -11979,75 +11979,75 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.4.tgz",
-      "integrity": "sha512-FJg/6a3s2YrUaqZ+/DJZzeZqfxbbWrynQMT1C5wlIEq9aDLXCFpPM/PiOyJh0ahxc0XPmi6uo38Poq+GJTuKWw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.5.tgz",
+      "integrity": "sha512-SKnGTdYcoN04Y2DvE0/Y7/MjkA+ltsmbuH/y/hR7Ob7tsj+8ZdOYuk+YvW1B8dY20nDPHP58XgDTSm2nA8BzzA==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.4.tgz",
-      "integrity": "sha512-LXraazvQQFBgxIg3Htny6G5V5he9EK7oS4jWtMdTGIikmD/OGByOv8ZjLuVLZLtVm3UIvaAiGtlQSLecxJoJDw==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.5.tgz",
+      "integrity": "sha512-YXiqgQ/9Rxg1dXp6brXbeQM1JDx9SwUY/36JiE+36FXqYEmDYbxld9qkX6GEzkc5rbwJ+RCitargnzEtwGW0mw==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.4.tgz",
-      "integrity": "sha512-SSST/dBymecllZxcqTCcSTCu5o1NKk9I+xcvhn/O9nH6GWjgvGgGkNqLbCarCa0jJ1ukvlBA138FagyrmZ/4rQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.5.tgz",
+      "integrity": "sha512-y8mhldb/WFZ6lFeowkGfi0cO/lBdiBqDk4T4LZLvCpoQp4Or/NzUN6P5NzBQZ5/b4oUHM/wQICEM+1wKA4qIVw==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.4.tgz",
-      "integrity": "sha512-p1lwdX0TVjaoDXQVuAkjtxVBbCL/urgxiMCBwuPDO7TikpXtSRivi+mIzBj5q7ypgICFmIAOW3TyupXeoPRAnA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.5.tgz",
+      "integrity": "sha512-wqJ3X7WQdTwSGi0kIDEmzw34QHISRIQ5uvC+VXmsIlCPFcMA+zM5723uh8NfuKGquDMiEMS31a83QgkuHMYbwQ==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.4.tgz",
-      "integrity": "sha512-67PZlgkCn3TDxacdVft0xqDCL7Io1/C4xbAs0+oSQ0xzp6OzN2RNpuKjHJrJgKd0DsE1XZ9sCP27Qv0591yfyg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.5.tgz",
+      "integrity": "sha512-WnhdM5duONMvt2CncAl+9pim0wBxDS2lHoo7ub/o/i1bRbs11UTzosKzEXVaTDCUkCX2c32lIDi1WcN2ZPkcdw==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.4.tgz",
-      "integrity": "sha512-OnOWixhhw7aU22TQdQLYrgpgFq0oA1wGgnjAiHJ+St7MLj82KTDyM9UcymAMbGYy6nG/TFOOHdTmRMtCRNOw0g==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.5.tgz",
+      "integrity": "sha512-Jq2H68yQ4bLUhR/XQnbw3LDW0GMQn355qx6rU36BthDLeGue7YV7MqNPa8GKvrpPocEMW77nWx/1yI6w6J07gw==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.4.tgz",
-      "integrity": "sha512-UoRMzPZnsAavdWtVylYxH8DNC7Uy0i6RrvNwT4PyQVdfANBn2omsUkcH5lgS2O7oaz0nAYLk1vqyZDO7+tJotA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.5.tgz",
+      "integrity": "sha512-KgPjwdbhDqXI7ghNN8V/WAiLquc9Ebe8KBrNNEL0NQr+yd9CyKJ6KqjayVkmX+hbHzbyvbui/5wh/p3CZQ9xcQ==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.4.tgz",
-      "integrity": "sha512-nM+MA/frxlTLUKLJKorctdI20/ugfHRjVEEkcLp/58LGG7slNaP1E5d5dRA1yX6ISjPcQAkywas5VlGCg+uTvA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.5.tgz",
+      "integrity": "sha512-O2ErUTvCJ6DkNTSr9pbu1n3tcqykqE/ebty1rwClzIYdOgpB3T2MfEPP+K7GhUR87wmN/hlihO9ch7qpVFDGKw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.4.tgz",
-      "integrity": "sha512-GoRHxkuW4u4yKw734B9SzxJwVdyEJosaZ62P7ifOwcujTxhgBt3y76V2nNUrsSuopcKI2ZTDjaa+2wd5zyeXbA==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.5.tgz",
+      "integrity": "sha512-1eIlZmlO/VRjxxzUBcVosf54AFU3ltAzHi+BJA+9U/lPxCYIsT+R4uO3QksRzRjKWhVQMRjEnlXyyq5SKJm7BA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.4.tgz",
-      "integrity": "sha512-6TQkQze0ievXwHJcVUrIULwCYVe3ccX6T0JgZ1SiMeXpHxISN7VJF/O8uSCw1JvXZYZ6ud0CJ7nfC5HXivgfPg==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.5.tgz",
+      "integrity": "sha512-oromsfokbEuVb0CBLLE7R9qX3KGXucZpsojLpzUh1QJjuy1QkrPJncwr8xmWQnwgtQ6ecMWXgXPB+qtvizT9Tw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.4.tgz",
-      "integrity": "sha512-CsbX/IXuZ5VSmWCpSetG2HD6VO5FTsO39WNp2IR2Ut/uom9XtLDJAZqjQEnbUTLGHuwDKFjrIO3LkhtROXLE/g==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.5.tgz",
+      "integrity": "sha512-a/51L5KzBpeZSW9LbekMo3I3Cwul+V+QKwbEIMA+Qwb2qrlcn1L9h3lt8cHqNTFt2y72ce6aTwDTw1lyi5oIRA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.4.tgz",
-      "integrity": "sha512-JtYuWzKXKLDMgE/xTcFtCm1MiCIRaAc5XYZfYX3n/ZWSI1SJS/GMm+Su0SAHJgRFavJh6U/p998YwO/iGTIgqQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.5.tgz",
+      "integrity": "sha512-/SoXW1Ntpmpw3AXAzfDRaQidnd8kbZ2oSni8u5z0yw6t4RwJvmdZy1eOaAADRThWKV+2oU90++LSnXJIwBRWYQ==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -16388,23 +16388,23 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.4.tgz",
-      "integrity": "sha512-DA4g97BM4Z0nKtDvCTm58RxdvoQyYzeg0AeVbh0N4Y/D8ELrNu47lQeEgRGF8hV4eQ+Sal90zxrJQQG/mPQ8CQ==",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.5.tgz",
+      "integrity": "sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==",
       "requires": {
-        "@next/env": "12.1.4",
-        "@next/swc-android-arm-eabi": "12.1.4",
-        "@next/swc-android-arm64": "12.1.4",
-        "@next/swc-darwin-arm64": "12.1.4",
-        "@next/swc-darwin-x64": "12.1.4",
-        "@next/swc-linux-arm-gnueabihf": "12.1.4",
-        "@next/swc-linux-arm64-gnu": "12.1.4",
-        "@next/swc-linux-arm64-musl": "12.1.4",
-        "@next/swc-linux-x64-gnu": "12.1.4",
-        "@next/swc-linux-x64-musl": "12.1.4",
-        "@next/swc-win32-arm64-msvc": "12.1.4",
-        "@next/swc-win32-ia32-msvc": "12.1.4",
-        "@next/swc-win32-x64-msvc": "12.1.4",
+        "@next/env": "12.1.5",
+        "@next/swc-android-arm-eabi": "12.1.5",
+        "@next/swc-android-arm64": "12.1.5",
+        "@next/swc-darwin-arm64": "12.1.5",
+        "@next/swc-darwin-x64": "12.1.5",
+        "@next/swc-linux-arm-gnueabihf": "12.1.5",
+        "@next/swc-linux-arm64-gnu": "12.1.5",
+        "@next/swc-linux-arm64-musl": "12.1.5",
+        "@next/swc-linux-x64-gnu": "12.1.5",
+        "@next/swc-linux-x64-musl": "12.1.5",
+        "@next/swc-win32-arm64-msvc": "12.1.5",
+        "@next/swc-win32-ia32-msvc": "12.1.5",
+        "@next/swc-win32-x64-msvc": "12.1.5",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.1"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "^2.3.1",
         "clipboard": "^2.0.10",
         "date-fns": "^2.28.0",
-        "dayjs": "^1.11.0",
+        "dayjs": "^1.11.1",
         "favicons": "^6.2.2",
         "highlight.js": "^10.7.2",
         "json2yaml": "^1.1.0",
@@ -4183,9 +4183,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -13857,9 +13857,9 @@
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA=="
     },
     "debug": {
       "version": "2.6.9",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -41,7 +41,7 @@
         "webpack": "^5.71.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.20.2",
+        "@playwright/test": "^1.21.0",
         "cypress": "^9.5.3",
         "eslint": "^8.12.0",
         "eslint-config-next": "^12.1.4",
@@ -1881,9 +1881,9 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.2.tgz",
-      "integrity": "sha512-unkLa+xe/lP7MVC0qpgadc9iSG1+LEyGBzlXhGS/vLGAJaSFs8DNfI89hNd5shHjWfNzb34JgPVnkRKCSNo5iw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
+      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.16.7",
@@ -1915,7 +1915,7 @@
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
-        "playwright-core": "1.20.2",
+        "playwright-core": "1.21.0",
         "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
@@ -8160,9 +8160,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.2.tgz",
-      "integrity": "sha512-iV6+HftSPalynkq0CYJala1vaTOq7+gU9BRfKCdM9bAxNq/lFLrwbluug2Wt5OoUwbMABcnTThIEm3/qUhCdJQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
+      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
       "dev": true,
       "dependencies": {
         "colors": "1.4.0",
@@ -12077,9 +12077,9 @@
       }
     },
     "@playwright/test": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.2.tgz",
-      "integrity": "sha512-unkLa+xe/lP7MVC0qpgadc9iSG1+LEyGBzlXhGS/vLGAJaSFs8DNfI89hNd5shHjWfNzb34JgPVnkRKCSNo5iw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
+      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.16.7",
@@ -12111,7 +12111,7 @@
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
-        "playwright-core": "1.20.2",
+        "playwright-core": "1.21.0",
         "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
@@ -16833,9 +16833,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.2.tgz",
-      "integrity": "sha512-iV6+HftSPalynkq0CYJala1vaTOq7+gU9BRfKCdM9bAxNq/lFLrwbluug2Wt5OoUwbMABcnTThIEm3/qUhCdJQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
+      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
       "dev": true,
       "requires": {
         "colors": "1.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "react-timeago": "^6.2.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
-    "sass": "^1.49.11",
+    "sass": "^1.50.0",
     "sass-loader": "^12.6.0",
     "serve": "^13.0.2",
     "spinkit": "^2.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "json2yaml": "^1.1.0",
     "lodash": "^4.17.21",
     "mini-svg-data-uri": "^1.4.4",
-    "next": "^12.1.4",
+    "next": "^12.1.5",
     "normalize.css": "^8.0.1",
     "nprogress": "^0.2.0",
     "parse-content-range-header": "^0.2.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "@playwright/test": "^1.21.0",
     "cypress": "^9.5.3",
     "eslint": "^8.12.0",
-    "eslint-config-next": "^12.1.4",
+    "eslint-config-next": "^12.1.5",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-webpack-plugin": "^3.1.1",
     "start-server-and-test": "^1.14.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
     "webpack": "^5.71.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.20.2",
+    "@playwright/test": "^1.21.0",
     "cypress": "^9.5.3",
     "eslint": "^8.12.0",
     "eslint-config-next": "^12.1.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.3.1",
     "clipboard": "^2.0.10",
     "date-fns": "^2.28.0",
-    "dayjs": "^1.11.0",
+    "dayjs": "^1.11.1",
     "favicons": "^6.2.2",
     "highlight.js": "^10.7.2",
     "json2yaml": "^1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   "author": "Michel Kraemer",
   "license": "Apache-2.0",
   "dependencies": {
-    "@monaco-editor/react": "^4.4.1",
+    "@monaco-editor/react": "^4.4.2",
     "@popperjs/core": "^2.11.5",
     "@vertx/eventbus-bridge-client.js": "^1.0.0",
     "body-scroll-lock": "^3.1.5",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump micrometer-registry-prometheus from 1.8.4 to 1.8.5 (#238) @dependabot
* Bump flyway-core from 8.5.5 to 8.5.8 (#237) @dependabot
* Bump dayjs from 1.11.0 to 1.11.1 in /ui (#236) @dependabot
* Bump @playwright/test from 1.20.2 to 1.21.0 in /ui (#235) @dependabot
* Bump @monaco-editor/react from 4.4.1 to 4.4.2 in /ui (#234) @dependabot
* Bump eslint-config-next from 12.1.4 to 12.1.5 in /ui (#233) @dependabot
* Bump next from 12.1.4 to 12.1.5 in /ui (#232) @dependabot
* Bump reactor-core from 3.4.16 to 3.4.17 (#231) @dependabot
* Bump cypress from 9.5.3 to 9.5.4 in /ui (#230) @dependabot
* Bump actions/upload-artifact from 2 to 3 (#228) @dependabot
* Bump actions/download-artifact from 2 to 3 (#227) @dependabot
* Bump eslint from 8.12.0 to 8.13.0 in /ui (#225) @dependabot
* Bump sass from 1.49.11 to 1.50.0 in /ui (#221) @dependabot
