### PR TITLE
Added workflow name to submission

### DIFF
--- a/src/main/kotlin/model/Submission.kt
+++ b/src/main/kotlin/model/Submission.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 data class Submission(
     val id: String = UniqueID.next(),
     val workflow: Workflow,
+    val name: String? = workflow.name,
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     val priority: Int = workflow.priority,
     val startTime: Instant? = null,

--- a/ui/pages/workflows/[id].jsx
+++ b/ui/pages/workflows/[id].jsx
@@ -145,7 +145,7 @@ function WorkflowDetails({ id }) {
 
   if (workflows.items !== undefined && workflows.items.length > 0) {
     let w = workflows.items[0]
-    title = w.id
+    title = typeof w.name !== "undefined" ? w.name : w.id
 
     if (status === "ACCEPTED" || status === "RUNNING") {
       menu = (

--- a/ui/pages/workflows/index.jsx
+++ b/ui/pages/workflows/index.jsx
@@ -22,11 +22,12 @@ function WorkflowListItem({ item: workflow }) {
   return useMemo(() => {
     let href = "/workflows/[id]"
     let as = `/workflows/${workflow.id}`
+    let title = typeof workflow.name !== "undefined" ? workflow.name : workflow.id
 
     let progress = workflowToProgress(workflow)
 
     return <ListItem key={workflow.id} justAdded={workflow.justAdded}
-        deleted={workflow.deleted} linkHref={href} linkAs={as} title={workflow.id}
+        deleted={workflow.deleted} linkHref={href} linkAs={as} title={title}
         startTime={workflow.startTime} endTime={workflow.endTime}
         progress={progress} labels={workflow.requiredCapabilities} />
   }, [workflow])

--- a/ui/tests/workflows.spec.js
+++ b/ui/tests/workflows.spec.js
@@ -34,6 +34,37 @@ actions:
   await expect(status).toContainText("Success")
 })
 
+test("submit named workflow", async({ page, request }) => {
+  let name = "fred"
+  let workflow = `api: 4.5.0
+name: ${name}
+actions:
+  - type: execute
+    service: sleep
+    inputs:
+      - id: seconds
+        value: 1
+`
+
+  // submit workflow
+  let response = await request.post("/workflows", {
+    data: workflow
+  })
+  expect(response.status()).toBe(202)
+  let submissionId = (await response.json()).id
+
+  // visit page after the workflow has been submitted
+  await page.goto("/workflows")
+
+  // check if list contains new row for the workflow
+  let row = page.locator(`div.list-item:has(a:text("${name}"))`)
+  await expect(row).toBeVisible()
+
+  // check if list does not contain a row with the submission id
+  let rowNotPresent = page.locator(`div.list-item:has(a:text("${submissionId}"))`)
+  await expect(rowNotPresent).not.toBeVisible()
+})
+
 test("submit workflow and check details", async({ page, request }) => {
   // visit page before the workflow has been submitted
   // wait until the workflow list has been loaded


### PR DESCRIPTION
Currently the auto generated submission ID is displayed in the UI. However, a workflow can have a user defined name. It makes sense to use the workflow name (if present) to name the submission as well. In this case, the user defined name could also be displayed on the UI pages.