### PR TITLE
Support human-readable durations for config values

### DIFF
--- a/conf/steep.yaml
+++ b/conf/steep.yaml
@@ -65,16 +65,16 @@ steep:
         # - /data:/data
 
   controller:
-    lookupIntervalMilliseconds: 2000
+    lookupInterval: 2s
     lookupMaxErrors: 5
-    lookupOrphansIntervalMilliseconds: 300000
-    lookupOrphansInitialDelayMilliseconds: 0
+    lookupOrphansInterval: 5m
+    lookupOrphansInitialDelay: 0m
 
   scheduler:
     enabled: true
-    lookupIntervalMilliseconds: 20000
-    lookupOrphansIntervalMilliseconds: 300000
-    lookupOrphansInitialDelayMilliseconds: 0
+    lookupInterval: 20s
+    lookupOrphansInterval: 5m
+    lookupOrphansInitialDelay: 0s
 
   db:
     driver: inmemory
@@ -90,13 +90,13 @@ steep:
     setupsFile: conf/setups.yaml
     driver: openstack
     createdByTag: Steep
-    syncIntervalSeconds: 120
-    keepAliveIntervalSeconds: 30
+    syncInterval: 2m
+    keepAliveInterval: 30s
     timeouts:
-      sshReadySeconds: 300
-      agentReadySeconds: 300
-      createVMSeconds: 300
-      destroyVMSeconds: 300
+      sshReady: 5m
+      agentReady: 5m
+      createVM: 5m
+      destroyVM: 5m
 
     # agentPool:
     #   - capabilities:
@@ -153,4 +153,4 @@ setups:
     docker:
       image: steep/steep:unstable
     agent:
-      autoShutdownTimeoutMinutes: 30
+      autoShutdownTimeout: 30m

--- a/src/main/kotlin/ConfigConstants.kt
+++ b/src/main/kotlin/ConfigConstants.kt
@@ -117,9 +117,10 @@ object ConfigConstants {
   /**
    * The interval at which the [Main] thread looks for orphaned entries in the
    * remote agent registry. Such entries may happen if there is a network
-   * failure during deregistration of an agent.
+   * failure during deregistration of an agent. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CLUSTER_LOOKUP_ORPHANS_INTERVAL = "steep.cluster.lookupOrphansIntervalMilliseconds"
+  const val CLUSTER_LOOKUP_ORPHANS_INTERVAL = "steep.cluster.lookupOrphansInterval"
 
   /**
    * `true` if an HTTP server should be deployed
@@ -181,8 +182,9 @@ object ConfigConstants {
   const val HTTP_CORS_EXPOSE_HEADERS = "steep.http.cors.exposeHeaders"
 
   /**
-   * The number of seconds the results of a preflight request can be cached in
-   * a preflight result cache.
+   * The duration the results of a preflight request can be cached in
+   * a preflight result cache. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
   const val HTTP_CORS_MAX_AGE = "steep.http.cors.maxAge"
 
@@ -193,9 +195,10 @@ object ConfigConstants {
   const val CONTROLLER_ENABLED = "steep.controller.enabled"
 
   /**
-   * The interval at which the controller looks for accepted submissions
+   * The interval at which the controller looks for accepted submissions.
+   * The time can be specified as a human-readable duration (see [helper.toDuration]).
    */
-  const val CONTROLLER_LOOKUP_INTERVAL = "steep.controller.lookupIntervalMilliseconds"
+  const val CONTROLLER_LOOKUP_INTERVAL = "steep.controller.lookupInterval"
 
   /**
    * The maximum number of errors to tolerate when looking up the status
@@ -206,17 +209,19 @@ object ConfigConstants {
   /**
    * The interval at which the controller looks for orphaned running
    * submissions (i.e. submissions that are in the status `RUNNING' but that
-   * are currently not being processed by any [Controller])
+   * are currently not being processed by any [Controller]). The time can
+   * be specified as a human-readable duration (see [helper.toDuration]).
    */
-  const val CONTROLLER_LOOKUP_ORPHANS_INTERVAL = "steep.controller.lookupOrphansIntervalMilliseconds"
+  const val CONTROLLER_LOOKUP_ORPHANS_INTERVAL = "steep.controller.lookupOrphansInterval"
 
   /**
-   * The number of milliseconds the controller should wait after startup before
+   * The duration the controller should wait after startup before
    * it looks for orphaned running submissions for the first time. This property
    * is useful if you want to implement a rolling update from one Steep
-   * instance to another.
+   * instance to another. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CONTROLLER_LOOKUP_ORPHANS_INITIAL_DELAY = "steep.controller.lookupOrphansInitialDelayMilliseconds"
+  const val CONTROLLER_LOOKUP_ORPHANS_INITIAL_DELAY = "steep.controller.lookupOrphansInitialDelay"
 
   /**
    * `true` if the scheduler should be enabled. Set this value to `false` if
@@ -225,9 +230,11 @@ object ConfigConstants {
   const val SCHEDULER_ENABLED = "steep.scheduler.enabled"
 
   /**
-   * The interval in which the scheduler looks for registered process chains
+   * The interval in which the scheduler looks for registered process chains.
+   * The time can be specified as a human-readable duration
+   * (see [helper.toDuration]).
    */
-  const val SCHEDULER_LOOKUP_INTERVAL = "steep.scheduler.lookupIntervalMilliseconds"
+  const val SCHEDULER_LOOKUP_INTERVAL = "steep.scheduler.lookupInterval"
 
   /**
    * The interval at which the scheduler looks for orphaned running
@@ -235,19 +242,21 @@ object ConfigConstants {
    * that are currently not being processed by any [Scheduler]). Note that
    * the scheduler also always looks for orphaned process chains when it detects
    * that another scheduler instance has just left the cluster (regardless of
-   * the configured interval).
+   * the configured interval). The time can be specified as a human-readable
+   * duration (see [helper.toDuration]).
    */
-  const val SCHEDULER_LOOKUP_ORPHANS_INTERVAL = "steep.scheduler.lookupOrphansIntervalMilliseconds"
+  const val SCHEDULER_LOOKUP_ORPHANS_INTERVAL = "steep.scheduler.lookupOrphansInterval"
 
   /**
-   * The number of milliseconds the scheduler should wait after startup before
+   * The duration the scheduler should wait after startup before
    * it looks for orphaned running process chains for the first time. This
    * property is useful if you want to implement a rolling update from one Steep
    * instance to another. Note that the scheduler also looks for orphaned
    * process chains when another scheduler instance has just left the cluster,
-   * even if the initial delay has not passed by yet.
+   * even if the initial delay has not passed by yet. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val SCHEDULER_LOOKUP_ORPHANS_INITIAL_DELAY = "steep.scheduler.lookupOrphansInitialDelayMilliseconds"
+  const val SCHEDULER_LOOKUP_ORPHANS_INITIAL_DELAY = "steep.scheduler.lookupOrphansInitialDelay"
 
   /**
    * `true` if this Steep instance should be able to execute process
@@ -272,17 +281,19 @@ object ConfigConstants {
   const val AGENT_INSTANCES = "steep.agent.instances"
 
   /**
-   * The number of minutes an agent should remain idle until it shuts itself
+   * The duration an agent should remain idle until it shuts itself
    * down gracefully. By default, this value is `0`, which means the agent
-   * never shuts itself down.
+   * never shuts itself down. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val AGENT_AUTO_SHUTDOWN_TIMEOUT = "steep.agent.autoShutdownTimeoutMinutes"
+  const val AGENT_AUTO_SHUTDOWN_TIMEOUT = "steep.agent.autoShutdownTimeout"
 
   /**
-   * The number of seconds that should pass before an idle agent decides
-   * that it is not busy anymore
+   * The duration that should pass before an idle agent decides
+   * that it is not busy anymore. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val AGENT_BUSY_TIMEOUT = "steep.agent.busyTimeoutSeconds"
+  const val AGENT_BUSY_TIMEOUT = "steep.agent.busyTimeout"
 
   /**
    * The number of output lines to collect at most from each executed service
@@ -343,44 +354,52 @@ object ConfigConstants {
   const val CLOUD_SETUPS_FILE = "steep.cloud.setupsFile"
 
   /**
-   * The number of seconds that should pass before the Cloud manager syncs
-   * its internal state with the Cloud again
+   * The duration that should pass before the Cloud manager syncs
+   * its internal state with the Cloud again. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CLOUD_SYNC_INTERVAL = "steep.cloud.syncIntervalSeconds"
+  const val CLOUD_SYNC_INTERVAL = "steep.cloud.syncInterval"
 
   /**
-   * The number of seconds that should pass before the Cloud manager sends
+   * The duration that should pass before the Cloud manager sends
    * keep-alive messages to a minimum of remote agents again (so that they
    * do not shut down themselves). See [model.setup.Setup.minVMs].
+   * The time can be specified as a human-readable duration
+   * (see [helper.toDuration]).
    */
-  const val CLOUD_KEEP_ALIVE_INTERVAL = "steep.cloud.keepAliveIntervalSeconds"
+  const val CLOUD_KEEP_ALIVE_INTERVAL = "steep.cloud.keepAliveInterval"
 
   /**
-   * The maximum number of seconds the cloud manager should try to log in to a
+   * The maximum duration the cloud manager should try to log in to a
    * new VM via SSH. The cloud manager will make a login attempt every 2
-   * seconds until it is successful or until the maximum number of seconds have
-   * passed, in which case it will destroy the VM.
+   * seconds until it is successful or until the maximum duration has
+   * passed, in which case it will destroy the VM. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CLOUD_TIMEOUTS_SSHREADY = "steep.cloud.timeouts.sshReadySeconds"
+  const val CLOUD_TIMEOUTS_SSHREADY = "steep.cloud.timeouts.sshReady"
 
   /**
-   * The maximum number of seconds the cloud manager should wait for an agent
+   * The maximum duration the cloud manager should wait for an agent
    * on a new VM to become available (i.e. how long a new Steep instance may
-   * take to register with the cluster) before it destroys the VM again
+   * take to register with the cluster) before it destroys the VM again.
+   * The time can be specified as a human-readable duration
+   * (see [helper.toDuration]).
    */
-  const val CLOUD_TIMEOUTS_AGENTREADY = "steep.cloud.timeouts.agentReadySeconds"
+  const val CLOUD_TIMEOUTS_AGENTREADY = "steep.cloud.timeouts.agentReady"
 
   /**
-   * The maximum number of seconds that creating a VM may take before it is
-   * aborted with an error
+   * The maximum duration that creating a VM may take before it is
+   * aborted with an error. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CLOUD_TIMEOUTS_CREATEVM = "steep.cloud.timeouts.createVMSeconds"
+  const val CLOUD_TIMEOUTS_CREATEVM = "steep.cloud.timeouts.createVM"
 
   /**
-   * The maximum number of seconds that destroying a VM may take before it is
-   * aborted with an error
+   * The maximum duration that destroying a VM may take before it is
+   * aborted with an error. The time can be specified
+   * as a human-readable duration (see [helper.toDuration]).
    */
-  const val CLOUD_TIMEOUTS_DESTROYVM = "steep.cloud.timeouts.destroyVMSeconds"
+  const val CLOUD_TIMEOUTS_DESTROYVM = "steep.cloud.timeouts.destroyVM"
 
   /**
    * Describes parameters of remote agents the CloudManager maintains in its pool

--- a/src/main/kotlin/Controller.kt
+++ b/src/main/kotlin/Controller.kt
@@ -16,6 +16,7 @@ import db.SubmissionRegistry
 import db.SubmissionRegistry.ProcessChainStatus
 import db.SubmissionRegistryFactory
 import helper.JsonUtils
+import helper.toDuration
 import io.prometheus.client.Gauge
 import io.vertx.core.eventbus.MessageConsumer
 import io.vertx.core.json.JsonObject
@@ -104,12 +105,12 @@ class Controller : CoroutineVerticle() {
           "`$OUT_PATH'. Point both configuration items to different locations.")
     }
 
-    lookupInterval = config.getLong(CONTROLLER_LOOKUP_INTERVAL, lookupInterval)
+    lookupInterval = config.getString(CONTROLLER_LOOKUP_INTERVAL)?.toDuration()?.toMillis() ?: lookupInterval
     lookupMaxErrors = config.getLong(CONTROLLER_LOOKUP_MAXERRORS, lookupMaxErrors)
-    lookupOrphansInterval = config.getLong(CONTROLLER_LOOKUP_ORPHANS_INTERVAL,
-        lookupOrphansInterval)
-    val lookupOrphansInitialDelay = config.getLong(CONTROLLER_LOOKUP_ORPHANS_INITIAL_DELAY,
-        DEFAULT_LOOKUP_ORPHANS_INITIAL_DELAY)
+    lookupOrphansInterval = config.getString(CONTROLLER_LOOKUP_ORPHANS_INTERVAL)?.toDuration()?.toMillis() ?:
+        lookupOrphansInterval
+    val lookupOrphansInitialDelay = config.getString(CONTROLLER_LOOKUP_ORPHANS_INITIAL_DELAY)?.toDuration()?.toMillis() ?:
+        DEFAULT_LOOKUP_ORPHANS_INITIAL_DELAY
 
     // periodically look for new submissions and execute them
     periodicLookupJob = launch {

--- a/src/main/kotlin/HttpEndpoint.kt
+++ b/src/main/kotlin/HttpEndpoint.kt
@@ -51,6 +51,7 @@ import helper.RangeParser
 import helper.UniqueID
 import helper.WorkflowValidator
 import helper.YamlUtils
+import helper.toDuration
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.vertx.core.Promise
@@ -414,7 +415,8 @@ class HttpEndpoint : CoroutineVerticle() {
     }
 
     // configure max age in seconds
-    val maxAge = config.getInteger(ConfigConstants.HTTP_CORS_MAX_AGE, -1)
+    val maxAge = config.getString(
+        ConfigConstants.HTTP_CORS_MAX_AGE)?.toDuration()?.toSeconds()?.toInt() ?: -1
     corsHandler.maxAgeSeconds(maxAge)
 
     return corsHandler

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -11,6 +11,7 @@ import helper.JsonUtils
 import helper.LazyJsonObjectMessageCodec
 import helper.UniqueID
 import helper.loadTemplate
+import helper.toDuration
 import io.micrometer.core.instrument.Clock
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
@@ -194,7 +195,7 @@ suspend fun main() {
   // Look for orphaned entries in the remote agent registry from time to time.
   // Such entries may happen if there is a network failure during deregistration
   // of an agent.
-  val lookupOrphansInterval = conf.getLong(ConfigConstants.CLUSTER_LOOKUP_ORPHANS_INTERVAL, 300_000L) // 5 minutes
+  val lookupOrphansInterval = conf.getString(ConfigConstants.CLUSTER_LOOKUP_ORPHANS_INTERVAL, "5m").toDuration().toMillis()
   val remoteAgentRegistry = RemoteAgentRegistry(vertx)
   CoroutineScope(vertx.dispatcher()).launch {
     while (true) {

--- a/src/main/kotlin/Scheduler.kt
+++ b/src/main/kotlin/Scheduler.kt
@@ -18,6 +18,7 @@ import db.SubmissionRegistry.ProcessChainStatus.REGISTERED
 import db.SubmissionRegistry.ProcessChainStatus.RUNNING
 import db.SubmissionRegistry.ProcessChainStatus.SUCCESS
 import db.SubmissionRegistryFactory
+import helper.toDuration
 import io.prometheus.client.Gauge
 import io.vertx.core.Promise
 import io.vertx.core.json.JsonArray
@@ -120,9 +121,9 @@ class Scheduler : CoroutineVerticle() {
     agentRegistry = AgentRegistryFactory.create(vertx)
 
     // read configuration
-    val lookupInterval = config.getLong(SCHEDULER_LOOKUP_INTERVAL, 20000L)
-    val lookupOrphansInterval = config.getLong(SCHEDULER_LOOKUP_ORPHANS_INTERVAL, 300_000L)
-    val lookupOrphansInitialDelay = config.getLong(SCHEDULER_LOOKUP_ORPHANS_INITIAL_DELAY, 0L)
+    val lookupInterval = config.getString(SCHEDULER_LOOKUP_INTERVAL, "20s").toDuration().toMillis()
+    val lookupOrphansInterval = config.getString(SCHEDULER_LOOKUP_ORPHANS_INTERVAL, "5m").toDuration().toMillis()
+    val lookupOrphansInitialDelay = config.getString(SCHEDULER_LOOKUP_ORPHANS_INITIAL_DELAY, "0s").toDuration().toMillis()
 
     // periodically look for new process chains and execute them
     periodicLookupJob = launch {

--- a/src/main/kotlin/Steep.kt
+++ b/src/main/kotlin/Steep.kt
@@ -8,6 +8,7 @@ import db.SubmissionRegistry
 import helper.CompressedJsonObjectMessageCodec
 import helper.JsonUtils
 import helper.Shell
+import helper.toDuration
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.eventbus.Message
 import io.vertx.core.impl.NoStackTraceThrowable
@@ -72,10 +73,10 @@ class Steep : CoroutineVerticle() {
   private var lastExecuteTime = Instant.now()
 
   override suspend fun start() {
-    busyTimeout = Duration.ofSeconds(config.getLong(
-        ConfigConstants.AGENT_BUSY_TIMEOUT, 60L))
-    autoShutdownTimeout = Duration.ofMinutes(config.getLong(
-        ConfigConstants.AGENT_AUTO_SHUTDOWN_TIMEOUT, 0))
+    busyTimeout = config.getString(
+        ConfigConstants.AGENT_BUSY_TIMEOUT, "1m").toDuration()
+    autoShutdownTimeout = config.getString(
+        ConfigConstants.AGENT_AUTO_SHUTDOWN_TIMEOUT, "0m").toDuration()
     agentId = config.getString(ConfigConstants.AGENT_ID) ?:
         throw IllegalStateException("Missing configuration item " +
             "`${ConfigConstants.AGENT_ID}'")

--- a/src/test/kotlin/SteepTest.kt
+++ b/src/test/kotlin/SteepTest.kt
@@ -72,7 +72,7 @@ class SteepTest {
     val config = json {
       obj(
           ConfigConstants.AGENT_CAPABILTIIES to array("docker", "gpu"),
-          ConfigConstants.AGENT_BUSY_TIMEOUT to 1L,
+          ConfigConstants.AGENT_BUSY_TIMEOUT to "1s",
           ConfigConstants.AGENT_ID to agentId,
           ConfigConstants.LOGS_PROCESSCHAINS_ENABLED to true,
           ConfigConstants.LOGS_PROCESSCHAINS_PATH to processChainLogPath

--- a/src/test/kotlin/cloud/CloudManagerTest.kt
+++ b/src/test/kotlin/cloud/CloudManagerTest.kt
@@ -11,6 +11,7 @@ import db.VMRegistryFactory
 import helper.LazyJsonObjectMessageCodec
 import helper.UniqueID
 import helper.YamlUtils
+import helper.toDuration
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -61,8 +62,8 @@ class CloudManagerTest {
     private const val MY_OLD_VM = "MY_OLD_VM"
     private const val MY_OLD_VOLUME = "MY_OLD_VOLUME"
     private const val CREATED_BY_TAG = "CloudManagerTest"
-    private const val SYNC_INTERVAL = 2
-    private const val KEEP_ALIVE_INTERVAL = 1
+    private const val SYNC_INTERVAL = "2s"
+    private const val KEEP_ALIVE_INTERVAL = "1s"
     private const val AZ01 = "az-01"
     private const val AZ02 = "az-02"
     private const val DUMMY_TEXT = "THIS IS A DUMMY TEXT"
@@ -771,7 +772,7 @@ class CloudManagerTest {
     fun tryCreateMin(vertx: Vertx, ctx: VertxTestContext) {
       CoroutineScope(vertx.dispatcher()).launch {
         // give the CloudManager enough time to call sync() at least two times
-        delay(SYNC_INTERVAL * 2 * 1000L)
+        delay(SYNC_INTERVAL.toDuration().toMillis() * 2)
 
         ctx.coVerify {
           coVerify(exactly = 2) {
@@ -920,7 +921,7 @@ class CloudManagerTest {
     fun tryCreateMin(vertx: Vertx, ctx: VertxTestContext) {
       CoroutineScope(vertx.dispatcher()).launch {
         // give the CloudManager enough time to call sync() at least once
-        delay(SYNC_INTERVAL * 2 * 1000L)
+        delay(SYNC_INTERVAL.toDuration().toMillis() * 2)
 
         ctx.coVerify {
           coVerify(exactly = 2) {


### PR DESCRIPTION
Currently many config values have a time unit in their name. It would be more flexible if the user could specify the used unit in the value of the config variable. Example

`lookupIntervalMilliseconds: 2000`

becomes

`lookupInterval: 2s`
