### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
     implementation("commons-codec:commons-codec:1.15")
     implementation("commons-io:commons-io:2.11.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
     implementation("com.github.luben:zstd-jni:1.5.2-2")
     implementation("com.github.zafarkhaja:java-semver:0.9.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation("commons-codec:commons-codec:1.15")
     implementation("commons-io:commons-io:2.11.0")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
     implementation("com.github.luben:zstd-jni:1.5.2-2")
     implementation("com.github.zafarkhaja:java-semver:0.9.0")
     implementation("com.google.guava:guava:31.1-jre")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -32,7 +32,7 @@
         "react-timeago": "^6.2.1",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.7",
-        "sass": "^1.51.0",
+        "sass": "^1.52.1",
         "sass-loader": "^12.6.0",
         "serve": "^13.0.2",
         "sockjs-client": "^1.6.0",
@@ -7363,9 +7363,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
-      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
+      "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -14461,9 +14461,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
-      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.1.tgz",
+      "integrity": "sha512-fSzYTbr7z8oQnVJ3Acp9hV80dM1fkMN7mSD/25mpcct9F7FPBMOI8krEYALgU1aZoqGhQNhTPsuSmxjnIvAm4Q==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -44,7 +44,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.22.0",
-        "cypress": "^9.6.0",
+        "cypress": "^9.7.0",
         "eslint": "^8.15.0",
         "eslint-config-next": "^12.1.6",
         "eslint-plugin-cypress": "^2.12.1",
@@ -2753,9 +2753,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -11013,9 +11013,9 @@
       }
     },
     "cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,7 +24,7 @@
         "normalize.css": "^8.0.1",
         "nprogress": "^0.2.0",
         "parse-content-range-header": "^0.2.4",
-        "postcss": "^8.4.13",
+        "postcss": "^8.4.14",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-feather": "^2.0.9",
@@ -6061,9 +6061,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6687,9 +6687,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "funding": [
         {
           "type": "opencollective",
@@ -6701,7 +6701,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.3",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -13489,9 +13489,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -13954,11 +13954,11 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "postcss": {
-      "version": "8.4.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
-      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "requires": {
-        "nanoid": "^3.3.3",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.22.0",
-    "cypress": "^9.6.0",
+    "cypress": "^9.7.0",
     "eslint": "^8.15.0",
     "eslint-config-next": "^12.1.6",
     "eslint-plugin-cypress": "^2.12.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "normalize.css": "^8.0.1",
     "nprogress": "^0.2.0",
     "parse-content-range-header": "^0.2.4",
-    "postcss": "^8.4.13",
+    "postcss": "^8.4.14",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-feather": "^2.0.9",

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "react-timeago": "^6.2.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.7",
-    "sass": "^1.51.0",
+    "sass": "^1.52.1",
     "sass-loader": "^12.6.0",
     "serve": "^13.0.2",
     "sockjs-client": "^1.6.0",


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump cypress from 9.6.0 to 9.7.0 in /ui (#286) @dependabot
* Bump sass from 1.51.0 to 1.52.1 in /ui (#285) @dependabot
* Bump @playwright/test from 1.22.0 to 1.22.2 in /ui (#284) @dependabot
* Bump postcss from 8.4.13 to 8.4.14 in /ui (#280) @dependabot
* Bump sass-loader from 12.6.0 to 13.0.0 in /ui (#279) @dependabot
* Bump jackson-module-kotlin from 2.13.2 to 2.13.3 (#275) @dependabot
* Bump zstd-jni from 1.5.2-2 to 1.5.2-3 (#274) @dependabot
* Bump jackson-dataformat-yaml from 2.13.2 to 2.13.3 (#272) @dependabot
