### PR TITLE
Support version number in plugin

### DIFF
--- a/conf/plugins/common.yaml
+++ b/conf/plugins/common.yaml
@@ -2,4 +2,5 @@
 - name: fileOrEmptyList
   type: outputAdapter
   scriptFile: conf/plugins/fileOrEmptyList.kt
+  version: 1.0.0
   supportedDataType: fileOrEmptyList

--- a/src/main/kotlin/model/plugins/InitializerPlugin.kt
+++ b/src/main/kotlin/model/plugins/InitializerPlugin.kt
@@ -19,6 +19,7 @@ import kotlin.reflect.full.callSuspend
 data class InitializerPlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
     override val dependsOn: List<String> = emptyList(),
 
     /**

--- a/src/main/kotlin/model/plugins/OutputAdapterPlugin.kt
+++ b/src/main/kotlin/model/plugins/OutputAdapterPlugin.kt
@@ -22,6 +22,7 @@ import kotlin.reflect.full.callSuspend
 data class OutputAdapterPlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
 
     /**
      * The output data type this plugin supports

--- a/src/main/kotlin/model/plugins/Plugin.kt
+++ b/src/main/kotlin/model/plugins/Plugin.kt
@@ -36,6 +36,11 @@ interface Plugin {
   val scriptFile: String
 
   /**
+   * The version number of the plugin
+   */
+  val version: String?
+
+  /**
    * The compiled plugin
    */
   val compiledFunction: KFunction<*>

--- a/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
+++ b/src/main/kotlin/model/plugins/ProcessChainAdapterPlugin.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.full.callSuspend
 data class ProcessChainAdapterPlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
     override val dependsOn: List<String> = emptyList(),
 
     /**

--- a/src/main/kotlin/model/plugins/ProcessChainConsistencyCheckerPlugin.kt
+++ b/src/main/kotlin/model/plugins/ProcessChainConsistencyCheckerPlugin.kt
@@ -31,6 +31,7 @@ import kotlin.reflect.full.callSuspend
 data class ProcessChainConsistencyCheckerPlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
     override val dependsOn: List<String> = emptyList(),
 
     /**

--- a/src/main/kotlin/model/plugins/ProgressEstimatorPlugin.kt
+++ b/src/main/kotlin/model/plugins/ProgressEstimatorPlugin.kt
@@ -25,6 +25,7 @@ import kotlin.reflect.full.callSuspend
 data class ProgressEstimatorPlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
 
     /**
      * A list of IDs of the services this estimator plugin supports

--- a/src/main/kotlin/model/plugins/RuntimePlugin.kt
+++ b/src/main/kotlin/model/plugins/RuntimePlugin.kt
@@ -20,6 +20,7 @@ import kotlin.reflect.KFunction
 data class RuntimePlugin(
     override val name: String,
     override val scriptFile: String,
+    override val version: String? = null,
 
     /**
      * The name of the supported runtime environment

--- a/src/test/kotlin/db/PluginDependencyResolverTest.kt
+++ b/src/test/kotlin/db/PluginDependencyResolverTest.kt
@@ -15,6 +15,7 @@ class PluginDependencyResolverTest {
   private data class DummyPlugin(override val name: String,
       override val dependsOn: List<String>,
       override val scriptFile: String = "foobar.kt",
+      override val version: String? = null,
       override val compiledFunction: KFunction<*> = throwPluginNeedsCompile<Any>()) : DependentPlugin
 
   /**

--- a/src/test/kotlin/db/PluginRegistryTest.kt
+++ b/src/test/kotlin/db/PluginRegistryTest.kt
@@ -161,9 +161,9 @@ class PluginRegistryTest {
    */
   @Test
   fun findOutputAdapter() {
-    val adapter1 = OutputAdapterPlugin("a", "file.kts", "dataType")
-    val adapter2 = OutputAdapterPlugin("b", "file2.kts", "dataType")
-    val adapter3 = OutputAdapterPlugin("c", "file3.kts", "custom")
+    val adapter1 = OutputAdapterPlugin("a", "file.kts", supportedDataType = "dataType")
+    val adapter2 = OutputAdapterPlugin("b", "file2.kts", supportedDataType = "dataType")
+    val adapter3 = OutputAdapterPlugin("c", "file3.kts", supportedDataType = "custom")
     val pr = PluginRegistry(listOf(adapter1, adapter2, adapter3))
     assertThat(pr.findOutputAdapter("dataType")).isSameAs(adapter2)
     assertThat(pr.findOutputAdapter("wrongDataType")).isNull()
@@ -361,9 +361,9 @@ class PluginRegistryTest {
    */
   @Test
   fun findRuntime() {
-    val adapter1 = RuntimePlugin("a", "file.kts", "ssh")
-    val adapter2 = RuntimePlugin("b", "file2.kts", "ssh")
-    val adapter3 = RuntimePlugin("c", "file3.kts", "http")
+    val adapter1 = RuntimePlugin("a", "file.kts", supportedRuntime = "ssh")
+    val adapter2 = RuntimePlugin("b", "file2.kts", supportedRuntime = "ssh")
+    val adapter3 = RuntimePlugin("c", "file3.kts", supportedRuntime = "http")
     val pr = PluginRegistry(listOf(adapter1, adapter2, adapter3))
     assertThat(pr.findRuntime("ssh")).isSameAs(adapter2)
     assertThat(pr.findRuntime("wrongRuntime")).isNull()


### PR DESCRIPTION
Currently the plugins do not support version numbers. This pull requests adds the property for all plugin types.

Old:
```
- name: fileOrEmptyList
  type: outputAdapter
  scriptFile: conf/plugins/fileOrEmptyList.kt
  supportedDataType: fileOrEmptyList
```

New:
```
- name: fileOrEmptyList
  type: outputAdapter
  scriptFile: conf/plugins/fileOrEmptyList.kt
  version: 1.0.0
  supportedDataType: fileOrEmptyList
```