### PR TITLE
Added option to enable only a subset of HTTP routes

### DIFF
--- a/conf/steep.yaml
+++ b/conf/steep.yaml
@@ -32,6 +32,7 @@ steep:
     port: 8080
     postMaxSize: 10485760  # 10 MB
     # basePath: /steep
+    # allowRoutes: .*
 
     # Cross-Origin Resource Sharing (CORS)
     cors:

--- a/src/main/kotlin/ConfigConstants.kt
+++ b/src/main/kotlin/ConfigConstants.kt
@@ -197,6 +197,11 @@ object ConfigConstants {
   const val HTTP_BASE_PATH = "steep.http.basePath"
 
   /**
+   * A regular expression for a whitelist of enabled routes on the HTTP server
+   */
+  const val HTTP_ALLOW_ROUTES = "steep.http.allowRoutes"
+
+  /**
    * `true` if Cross-Origin Resource Sharing (CORS) should be enabled
    */
   const val HTTP_CORS_ENABLE = "steep.http.cors.enable"

--- a/src/main/kotlin/HttpEndpoint.kt
+++ b/src/main/kotlin/HttpEndpoint.kt
@@ -381,6 +381,12 @@ class HttpEndpoint : CoroutineVerticle() {
             .setBodyLimit(config.getLong(ConfigConstants.HTTP_POST_MAX_SIZE, 1024L * 1024L)))
         .subRouter(sockJSRouter)
 
+    // disable all routes that are not whitelisted
+    val allowRoutes = config.getString(ConfigConstants.HTTP_ALLOW_ROUTES, ".*").toRegex()
+    router.routes
+        .filter { !it.path.matches(allowRoutes) }
+        .forEach { it.disable() }
+
     val baseRouter = Router.router(vertx)
     baseRouter.route("$basePath/*").subRouter(router)
     server.requestHandler(baseRouter).listen(port, host).await()


### PR DESCRIPTION
Currently, only the entire HTTP server or nothing can be started. However, sometimes you want to have only special routes, like `/metrics`, but not everything else. With this merge request the started routes can be configured in a whitelist. By default, all routes are launched.