### PR TITLE
Removed unused dependency vertx-shell

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
     implementation("io.vertx:vertx-micrometer-metrics:$vertxVersion")
     implementation("io.vertx:vertx-mongo-client:$vertxVersion")
     implementation("io.vertx:vertx-pg-client:$vertxVersion")
-    implementation("io.vertx:vertx-shell:$vertxVersion")
     implementation("io.vertx:vertx-web:$vertxVersion")
     implementation("io.vertx:vertx-web-client:$vertxVersion")
 


### PR DESCRIPTION
The dependency vertx-shell is not needed in Steep and contains a critical vulnerability. See also https://nvd.nist.gov/vuln/detail/CVE-2022-45047 This merge request removes the dependency.