### PR TITLE
Added the possibility to override the global autoShutdownTimeout for an agent in the setup

### DIFF
--- a/conf/setups/default/02_steep.sh
+++ b/conf/setups/default/02_steep.sh
@@ -14,6 +14,6 @@ docker run -d --name steep --restart=on-failure \
   -e "STEEP_CLUSTER_HAZELCAST_TCPENABLED=true" \
   -e "STEEP_AGENT_ID={{ agentId }}" \
   -e "STEEP_AGENT_CAPABILITIES=[{% for cap in agentCapabilities %}\"{{ cap }}\"{% if not loop.last %},{% endif %}{% endfor %}]" \
-  -e "STEEP_AGENT_AUTOSHUTDOWNTIMEOUTMINUTES={{ config["setups.default.agent.autoShutdownTimeoutMinutes"] }}" \
+  -e "STEEP_AGENT_AUTOSHUTDOWNTIMEOUT={% if setup.autoShutdownTimeout is empty %}{{ config["setups.default.agent.autoShutdownTimeout"] }}{% else %}{{ setup.autoShutdownTimeout }}{% endif %}" \
   -e "STEEP_SCHEDULER_ENABLED=false" \
   {{ config["setups.default.docker.image"] }}

--- a/src/main/kotlin/model/setup/Setup.kt
+++ b/src/main/kotlin/model/setup/Setup.kt
@@ -27,6 +27,9 @@ import ConfigConstants
  * `setup` context object in provisioning script templates
  * @param creation an optional policy that defines rules for creating VMs from
  * this setup (default values for this parameter are defined in the `steep.yaml`)
+ * @param autoShutdownTimeout an optional timeout after which the VM should be
+ * shut down when it is idle. This overrides the `autoShutdownTimeout` parameter
+ * from the `steep.yaml`
  * @author Michel Kraemer
  */
 data class Setup(
@@ -44,5 +47,6 @@ data class Setup(
     val sshUsername: String? = null,
     val additionalVolumes: List<Volume> = emptyList(),
     val parameters: Map<String, Any> = emptyMap(),
-    val creation: CreationPolicy? = null
+    val creation: CreationPolicy? = null,
+    val autoShutdownTimeout: String? = null
 )


### PR DESCRIPTION
Currently, an agent can shut itself down if it was idle for a certain period of time. This duration can be set via the global configuration `setups.default.agent.autoShutdownTimeout`. However, it is not possible to set an individual value for each setup. 

This pull request adds an optional parameter to the setup model that overrides the default `autoShutdownTimeout` from the global configuration. As a result, it is possible to specify different timeouts for different setups. 

An example `setups.yaml` can now look like this

```yml
- id: default
  flavor: 7d217779-4d7b-4689-8a40-c12a377b946d
  imageName: Ubuntu 18.04
  availabilityZone: az-01
  blockDeviceSizeGb: 50
  minVMs: 0
  maxVMs: 1
  autoShutdownTimeout: 1m # This is new

  provisioningScripts:
    - conf/setups/default/01_docker.sh
    - conf/setups/default/02_steep.sh

  providedCapabilities:
    - docker
```