### PR TITLE
Update access to the providedCapabilities in provisioning script

### DIFF
--- a/conf/setups/default/02_steep.sh
+++ b/conf/setups/default/02_steep.sh
@@ -13,7 +13,7 @@ docker run -d --name steep --restart=on-failure \
   -e "STEEP_CLUSTER_HAZELCAST_INTERFACES=[\"172.*.*.*\"]" \
   -e "STEEP_CLUSTER_HAZELCAST_TCPENABLED=true" \
   -e "STEEP_AGENT_ID={{ agentId }}" \
-  -e "STEEP_AGENT_CAPABILITIES=[{% for cap in agentCapabilities %}\"{{ cap }}\"{% if not loop.last %},{% endif %}{% endfor %}]" \
+  -e "STEEP_AGENT_CAPABILITIES=[{% for cap in setup.providedCapabilities %}\"{{ cap }}\"{% if not loop.last %},{% endif %}{% endfor %}]" \
   -e "STEEP_AGENT_AUTOSHUTDOWNTIMEOUTMINUTES={{ config["setups.default.agent.autoShutdownTimeoutMinutes"] }}" \
   -e "STEEP_SCHEDULER_ENABLED=false" \
   {{ config["setups.default.docker.image"] }}


### PR DESCRIPTION
Using `agentCapabilities` in provisioning scripts is deprecated. `setup.providedCapabilities` should be used. This pull requests adapts the usage in the example script for starting Steep on a VM. 

See also
https://github.com/steep-wms/steep/blob/6dd647e51d912d296be4686a07c131ea2a567523/src/main/kotlin/cloud/CloudManager.kt#L743 