### PR TITLE
Fixed missing yieldToInput renaming in inner loops

### DIFF
--- a/src/main/kotlin/ProcessChainGenerator.kt
+++ b/src/main/kotlin/ProcessChainGenerator.kt
@@ -381,6 +381,7 @@ class ProcessChainGenerator(workflow: Workflow, private val tmpPath: String,
             input = substitutions[action.input.id] ?: action.input,
             actions = newActions,
             yieldToOutput = action.yieldToOutput?.let { substitutions[it.id] ?: it },
+            yieldToInput = action.yieldToInput?.let { substitutions[it.id] ?: it },
             dependsOn = action.dependsOn.map { substitutions[it]?.id ?: it }
           )
         }

--- a/src/test/kotlin/ProcessChainGeneratorTest.kt
+++ b/src/test/kotlin/ProcessChainGeneratorTest.kt
@@ -197,6 +197,9 @@ class ProcessChainGeneratorTest {
         // action
         T("forEachYieldToInputNested"),
 
+        // Test if yield to input is also working in inner loops
+        T("forEachYieldToInputNestedDeep"),
+
         // Test if a recursive for-each action can have sub-actions that
         // lead to three process chains, one of which contains another
         // for-each action

--- a/src/test/resources/fixtures/forEachYieldToInputNestedDeep.yaml
+++ b/src/test/resources/fixtures/forEachYieldToInputNestedDeep.yaml
@@ -1,0 +1,30 @@
+vars:
+  - id: outer
+    value:
+      - "outer.txt"
+  - id: inner
+    value:
+      - "inner.txt"
+  - id: i
+  - id: o
+  - id: j
+  - id: innero
+actions:
+  - type: for
+    input: outer
+    enumerator: i
+    actions:
+      - type: for
+        input: inner
+        enumerator: j
+        actions:
+          - id: cp
+            type: execute
+            service: cp
+            inputs:
+              - id: input_file
+                var: j
+            outputs:
+              - id: output_file
+                var: o
+        yieldToInput: o

--- a/src/test/resources/fixtures/forEachYieldToInputNestedDeep_result.yaml
+++ b/src/test/resources/fixtures/forEachYieldToInputNestedDeep_result.yaml
@@ -1,0 +1,45 @@
+- chains:
+    - id: 1
+      executables:
+        - id: cp$0$0
+          path: cp
+          serviceId: cp
+          arguments:
+            - id: input_file
+              variable:
+                id: j$0$0
+                value: inner.txt
+              type: input
+              dataType: string
+            - id: output_file
+              variable:
+                id: o$0$0
+                value: /tmp/0
+              type: output
+              dataType: string
+  results:
+    o$0$0:
+      - innerCp.txt
+- chains:
+    - id: 3
+      executables:
+        - id: cp$0$1
+          path: cp
+          serviceId: cp
+          arguments:
+            - id: input_file
+              variable:
+                id: j$0$1
+                value: innerCp.txt
+              type: input
+              dataType: string
+            - id: output_file
+              variable:
+                id: o$0$1
+                value: /tmp/2
+              type: output
+              dataType: string
+  results:
+    o$0$1: [] # Simulating an empty list. In fact cp would copy the file again and again leading to an endless loop.
+- chains: []
+  results: {}


### PR DESCRIPTION
The `yieldToInput` attribute is not renamed in inner loops. As a result you get the error message `Cannot yield non-existing variable XXXX` whenever you want to add some data to the loop again.

See the following example. It should be an infinite loop. However, it aborts with the above error.

This pull request includes a unit test to reproduce the behaviour and adds the renaming in the `ProcessChainGenerator`

```yaml
api: 4.6.0
name: Iterator Test - Einfaches Yield to input geht nicht
vars:
  - id: wrapperList
    value: ['1']
actions:
  - type: execute
    service: touch
    outputs:
      - id: file
        var: touchOut

  - id: wrapper
    type: for
    input: wrapperList
    enumerator: currentWrapper
    actions:

      - type: for
        input: touchOut
        enumerator: innerEnumerator
        yieldToInput: copy
        actions:
          - type: execute
            service: cp
            inputs:
              - id: input_file
                var: innerEnumerator
            outputs:
              - id: output_file
                var: copy
```